### PR TITLE
Test import account view

### DIFF
--- a/app/views/auth/CreateAccountView/CreateAccountForm.tsx
+++ b/app/views/auth/CreateAccountView/CreateAccountForm.tsx
@@ -53,13 +53,13 @@ export const createAccountFormOnSubmit = async (
 };
 
 interface CreateAccountFormProps {
-  isTest: boolean;
+  isTest: boolean | undefined;
   onSubmit: typeof createAccountFormOnSubmit;
 }
 
 const CreateAccountForm: FC<CreateAccountFormProps> = ({
   isTest,
-  onSubmit = createAccountFormOnSubmit,
+  onSubmit,
 }: CreateAccountFormProps) => {
   const isMountedRef = useIsMountedRef();
   const { createAccount } = useMobileCoinD();

--- a/app/views/auth/CreateAccountView/CreateAccountForm.tsx
+++ b/app/views/auth/CreateAccountView/CreateAccountForm.tsx
@@ -86,7 +86,7 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
     onSubmit(pseduoProps, values, helpers);
   };
 
-  const isInitialValues = {
+  const initialValues = {
     accountName: '',
     checkedTerms: false,
     password: '',
@@ -116,7 +116,7 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
   return (
     <Formik
       isInitialValid={false}
-      initialValues={isInitialValues}
+      initialValues={initialValues}
       onSubmit={handleOnSubmit}
       validationSchema={validationSchema}
       validateOnMount

--- a/app/views/auth/CreateAccountView/CreateAccountForm.tsx
+++ b/app/views/auth/CreateAccountView/CreateAccountForm.tsx
@@ -127,14 +127,14 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
         return (
           <Form name="CreateAccountFormName">
             <Field
-              id="accountNameField"
+              id="CreateAccountForm-accountNameField"
               component={TextField}
               fullWidth
               label="Account Name (optional)"
               name="accountName"
             />
             <Field
-              id="passwordField"
+              id="CreateAccountForm-passwordField"
               component={TextField}
               fullWidth
               label="Password"
@@ -143,7 +143,7 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
               type="password"
             />
             <Field
-              id="passwordConfirmationField"
+              id="CreateAccountForm-passwordConfirmationField"
               component={TextField}
               fullWidth
               label="Password Confirmation"

--- a/app/views/auth/CreateAccountView/CreateAccountForm.tsx
+++ b/app/views/auth/CreateAccountView/CreateAccountForm.tsx
@@ -54,12 +54,12 @@ export const createAccountFormOnSubmit = async (
 
 interface CreateAccountFormProps {
   isTest: boolean;
-  onSubmit?: typeof createAccountFormOnSubmit;
+  onSubmit: typeof createAccountFormOnSubmit;
 }
 
 const CreateAccountForm: FC<CreateAccountFormProps> = ({
   isTest,
-  onSubmit,
+  onSubmit = createAccountFormOnSubmit,
 }: CreateAccountFormProps) => {
   const isMountedRef = useIsMountedRef();
   const { createAccount } = useMobileCoinD();
@@ -82,8 +82,6 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
     values: CreateAccountFormValues,
     helpers: FormikHelpers<CreateAccountFormValues>,
   ) => {
-    if (typeof onSubmit !== 'function') throw new Error('Cannot find onSubmit');
-
     const pseduoProps = { createAccount, isMountedRef };
     onSubmit(pseduoProps, values, helpers);
   };
@@ -102,8 +100,10 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
       'Account Name cannot be more than 64 characters.',
     ),
     // CBB: It appears that the checkedTerms error message is not working properly.
-    checkedTerms:
-      Yup.bool().oneOf([true], 'You must accept Terms of Use to use wallet.'),
+    checkedTerms: Yup.bool().oneOf(
+      [true],
+      'You must accept Terms of Use to use wallet.',
+    ),
     password: Yup.string()
       .min(8, 'Password must be at least 8 characters in length.')
       .max(99, 'Passwords cannot be more than 99 characters.')
@@ -197,10 +197,6 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
       }}
     </Formik>
   );
-};
-
-CreateAccountForm.defaultProps = {
-  onSubmit: createAccountFormOnSubmit,
 };
 
 export default CreateAccountForm;

--- a/app/views/auth/CreateAccountView/CreateAccountForm.tsx
+++ b/app/views/auth/CreateAccountView/CreateAccountForm.tsx
@@ -67,13 +67,15 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
   const [canCheck, setCanCheck] = React.useState(false);
   const [open, setOpen] = React.useState(false);
 
-  const handleClickOpen = () => {
-    setOpen(true);
-  };
-
   const handleCloseTerms = () => {
     setCanCheck(true);
     setOpen(false);
+  };
+
+  // FIX-ME: This hack is to avoid opening the Dialog -- which is causing some
+  // headaches in testing.
+  const handleClickOpen = () => {
+    return isTest ? handleCloseTerms() : setOpen(true);
   };
 
   const handleOnSubmit = async (
@@ -189,7 +191,6 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
             >
               Create Account
             </SubmitButton>
-            {isTest && <Button onClick={handleCloseTerms}>TEST BUTTON</Button>}
             <TermsOfUseDialog open={open} handleCloseTerms={handleCloseTerms} />
           </Form>
         );

--- a/app/views/auth/CreateAccountView/index.tsx
+++ b/app/views/auth/CreateAccountView/index.tsx
@@ -16,7 +16,9 @@ import LogoIcon from '../../../components/icons/LogoIcon';
 import routePaths from '../../../constants/routePaths';
 import useMobileCoinD from '../../../hooks/useMobileCoinD';
 import type { Theme } from '../../../theme';
-import CreateAccountForm from './CreateAccountForm';
+import CreateAccountForm, {
+  createAccountFormOnSubmit,
+} from './CreateAccountForm';
 
 interface CreateAccountViewProps {
   isTest?: boolean;
@@ -86,7 +88,10 @@ const CreateAccountView: FC<CreateAccountViewProps> = ({ isTest }: CreateAccount
               </Button>
             </Box>
           )}
-          <CreateAccountForm isTest={isTest || false} />
+          <CreateAccountForm
+            isTest={isTest}
+            onSubmit={createAccountFormOnSubmit}
+          />
           <Box my={3}>
             <Divider />
           </Box>

--- a/app/views/auth/ImportAccountView/index.tsx
+++ b/app/views/auth/ImportAccountView/index.tsx
@@ -3,10 +3,10 @@ import type { FC } from 'react';
 
 import {
   Box,
+  Button,
   Card,
   Container,
   Divider,
-  Link,
   Typography,
   makeStyles,
 } from '@material-ui/core';
@@ -16,7 +16,12 @@ import LogoIcon from '../../../components/icons/LogoIcon';
 import routePaths from '../../../constants/routePaths';
 import useMobileCoinD from '../../../hooks/useMobileCoinD';
 import type { Theme } from '../../../theme';
-import ImportAccountForm from './ImportAccountForm';
+import ImportAccountForm, { importAccountFormOnSubmit } from './ImportAccountForm';
+
+// CBB: this isTest pattern would be better managed with context and hooks.
+interface ImportAccountViewProps {
+  isTest?: boolean;
+}
 
 const useStyles = makeStyles((theme: Theme) => {
   return {
@@ -45,7 +50,9 @@ const useStyles = makeStyles((theme: Theme) => {
   };
 });
 
-const ImportAccountView: FC = () => {
+const ImportAccountView: FC<ImportAccountViewProps> = ({
+  isTest,
+}: ImportAccountViewProps) => {
   const classes = useStyles();
   const { encryptedEntropy } = useMobileCoinD();
 
@@ -66,34 +73,45 @@ const ImportAccountView: FC = () => {
             instead.
           </Typography>
           {encryptedEntropy && (
-            <>
+            <Box data-testid="overwrite-warning">
               <Typography variant="body2" paragraph>
                 It appears that this wallet is locked with an encrypted Entropy.
                 Importing an account will override the wallet. Please ensure
                 that you have secured your Entropy if you wish to change
                 accounts.
               </Typography>
-              <Link
+              <Button
+                color="secondary"
                 component={RouterLink}
                 to={routePaths.ROOT}
-                variant="body2"
-                paragraph
               >
                 Unlock this wallet
-              </Link>
-            </>
+              </Button>
+            </Box>
           )}
-          <ImportAccountForm />
+          <ImportAccountForm
+            isTest={isTest}
+            onSubmit={importAccountFormOnSubmit}
+          />
           <Box my={3}>
             <Divider />
           </Box>
-          <Link component={RouterLink} to={routePaths.CREATE} variant="body2">
+          <Button
+            color="secondary"
+            component={RouterLink}
+            to={routePaths.CREATE}
+            variant="outlined"
+          >
             Create account instead
-          </Link>
+          </Button>
         </Card>
       </Container>
     </Box>
   );
+};
+
+ImportAccountView.defaultProps = {
+  isTest: false,
 };
 
 export default ImportAccountView;

--- a/test/renderSnapshot.tsx
+++ b/test/renderSnapshot.tsx
@@ -41,6 +41,7 @@ const renderSnapshot = (
 
   const mockUseMobileCoinDFunctions = {
     createAccount: jest.fn(),
+    importAccount: jest.fn(),
     unlockWallet: jest.fn(),
   };
 

--- a/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
+++ b/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
@@ -39,8 +39,8 @@ function setupComponent() {
     },
   ) as HTMLInputElement;
   const checkTermsField = screen.getByRole('checkbox') as HTMLInputElement;
-  const specialTermsButton = screen.getByRole('button', {
-    name: 'TEST BUTTON',
+  const termsButton = screen.getByRole('button', {
+    name: 'Terms of Use',
   });
   const submitButton = screen.getByRole('button', { name: 'Create Account' });
 
@@ -53,8 +53,8 @@ function setupComponent() {
     mockUseMobileCoinDValues,
     passwordConfirmationField,
     passwordField,
-    specialTermsButton,
     submitButton,
+    termsButton,
     validAccountName64,
     validPassword99,
   };
@@ -138,7 +138,7 @@ describe('CreateAccountForm', () => {
       test('checkbox is disabled until reading terms', async () => {
         const {
           checkTermsField,
-          specialTermsButton,
+          termsButton,
         } = setupComponent();
         const expectedTermsMessage = 'You must read the Terms of Use before using the wallet.';
 
@@ -153,7 +153,7 @@ describe('CreateAccountForm', () => {
         });
 
         // Reading the terms removes message and allows you to click terms
-        userEvent.click(specialTermsButton);
+        userEvent.click(termsButton);
         await waitFor(() => {
           expect(termsMessage).not.toBeInTheDocument();
         });
@@ -277,7 +277,7 @@ describe('CreateAccountForm', () => {
           mockUseMobileCoinDValues,
           passwordConfirmationField,
           passwordField,
-          specialTermsButton,
+          termsButton,
           submitButton,
           validAccountName64,
           validPassword99,
@@ -294,7 +294,7 @@ describe('CreateAccountForm', () => {
         userEvent.type(accountNameField, validAccountName64);
         userEvent.type(passwordField, validPassword99);
         userEvent.type(passwordConfirmationField, validPassword99);
-        userEvent.click(specialTermsButton);
+        userEvent.click(termsButton);
         userEvent.click(checkTermsField);
         expect(accountNameField.value).toBe(validAccountName64);
         expect(passwordField.value).toBe(validPassword99);

--- a/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
+++ b/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
@@ -24,17 +24,14 @@ function setupComponent() {
   // Render Elements
   const form = screen.getByRole('form');
   const accountNameField = screen.getByLabelText('Account Name (optional)', {
-    exact: false,
     selector: 'input',
   }) as HTMLInputElement;
   const passwordField = screen.getByLabelText('Password', {
-    exact: true,
     selector: 'input',
   }) as HTMLInputElement;
   const passwordConfirmationField = screen.getByLabelText(
     'Password Confirmation',
     {
-      exact: true,
       selector: 'input',
     },
   ) as HTMLInputElement;

--- a/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
+++ b/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
@@ -314,6 +314,37 @@ describe('CreateAccountForm', () => {
           );
         });
       });
+
+      test('displays error when thrown', async () => {
+        const expectedErrorMessage = 'I am an error!';
+        const {
+          accountNameField,
+          checkTermsField,
+          mockUseMobileCoinDValues,
+          passwordConfirmationField,
+          passwordField,
+          termsButton,
+          submitButton,
+          validAccountName64,
+          validPassword99,
+        } = setupComponent();
+        // @ts-ignore mock
+        mockUseMobileCoinDValues.createAccount.mockImplementation(() => {
+          throw new Error(expectedErrorMessage);
+        });
+
+        // Enter valid form information & Submit
+        userEvent.type(accountNameField, validAccountName64);
+        userEvent.type(passwordField, validPassword99);
+        userEvent.type(passwordConfirmationField, validPassword99);
+        userEvent.click(termsButton);
+        userEvent.click(checkTermsField);
+        userEvent.click(submitButton);
+
+        await waitFor(() => {
+          expect(screen.getByText(expectedErrorMessage)).toBeInTheDocument();
+        });
+      });
     });
   });
 

--- a/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
+++ b/test/views/auth/CreateAccountView/CreateAccountForm.test.tsx
@@ -18,7 +18,7 @@ function setupComponent() {
   const validPassword99 = 'longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglon';
 
   const { mockUseMobileCoinDValues } = renderSnapshot(
-    <CreateAccountForm isTest />,
+    <CreateAccountForm onSubmit={createAccountFormOnSubmit} isTest />,
   );
 
   // Render Elements

--- a/test/views/auth/CreateAccountView/__snapshots__/CreateAccountView.test.tsx.snap
+++ b/test/views/auth/CreateAccountView/__snapshots__/CreateAccountView.test.tsx.snap
@@ -223,20 +223,6 @@ exports[`CreateAccountView component render it renders correctly 1`] = `
               </span>
             </button>
           </div>
-          <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="MuiButton-label"
-            >
-              TEST BUTTON
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
-          </button>
         </form>
         <div
           class="MuiBox-root MuiBox-root"

--- a/test/views/auth/CreateAccountView/__snapshots__/CreateAccountView.test.tsx.snap
+++ b/test/views/auth/CreateAccountView/__snapshots__/CreateAccountView.test.tsx.snap
@@ -76,8 +76,8 @@ exports[`CreateAccountView component render it renders correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
               data-shrink="false"
-              for="accountNameField"
-              id="accountNameField-label"
+              for="CreateAccountForm-accountNameField"
+              id="CreateAccountForm-accountNameField-label"
             >
               Account Name (optional)
             </label>
@@ -87,7 +87,7 @@ exports[`CreateAccountView component render it renders correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiInput-input"
-                id="accountNameField"
+                id="CreateAccountForm-accountNameField"
                 name="accountName"
                 type="text"
                 value=""
@@ -100,8 +100,8 @@ exports[`CreateAccountView component render it renders correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense"
               data-shrink="false"
-              for="passwordField"
-              id="passwordField-label"
+              for="CreateAccountForm-passwordField"
+              id="CreateAccountForm-passwordField-label"
             >
               Password
             </label>
@@ -111,7 +111,7 @@ exports[`CreateAccountView component render it renders correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
-                id="passwordField"
+                id="CreateAccountForm-passwordField"
                 name="password"
                 type="password"
                 value=""
@@ -124,8 +124,8 @@ exports[`CreateAccountView component render it renders correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense"
               data-shrink="false"
-              for="passwordConfirmationField"
-              id="passwordConfirmationField-label"
+              for="CreateAccountForm-passwordConfirmationField"
+              id="CreateAccountForm-passwordConfirmationField-label"
             >
               Password Confirmation
             </label>
@@ -135,7 +135,7 @@ exports[`CreateAccountView component render it renders correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
-                id="passwordConfirmationField"
+                id="CreateAccountForm-passwordConfirmationField"
                 name="passwordConfirmation"
                 type="password"
                 value=""

--- a/test/views/auth/ImportAccountView/ImportAccountForm.test.tsx
+++ b/test/views/auth/ImportAccountView/ImportAccountForm.test.tsx
@@ -1,0 +1,505 @@
+import React from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ImportAccountForm, {
+  importAccountFormOnSubmit,
+} from '../../../../app/views/auth/ImportAccountView/ImportAccountForm';
+import renderSnapshot from '../../../renderSnapshot';
+
+jest.mock('../../../../app/hooks/useMobileCoinD');
+
+function setupComponent() {
+  // Variables
+  const validAccountName64 = '64llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll';
+  const invalidAccountName65 = '65lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll';
+  const validEntropy = '0000000000000000000000000000000000000000000000000000000000000000';
+  const invalidEntropy = 'invalid';
+  const invalidPasswordShort = 'shooort';
+  const validPassword99 = 'longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglon';
+
+  const { mockUseMobileCoinDValues } = renderSnapshot(
+    <ImportAccountForm onSubmit={importAccountFormOnSubmit} isTest />,
+  );
+
+  // Render Elements
+  const form = screen.getByRole('form');
+  const accountNameField = screen.getByLabelText('Account Name (optional)', {
+    selector: 'input',
+  }) as HTMLInputElement;
+  const entropyField = screen.getByLabelText('Entropy', {
+    selector: 'input',
+  }) as HTMLInputElement;
+  const passwordField = screen.getByLabelText('Password', {
+    selector: 'input',
+  }) as HTMLInputElement;
+  const passwordConfirmationField = screen.getByLabelText(
+    'Password Confirmation',
+    {
+      selector: 'input',
+    },
+  ) as HTMLInputElement;
+  const checkTermsField = screen.getByRole('checkbox') as HTMLInputElement;
+  const termsButton = screen.getByRole('button', {
+    name: 'Terms of Use',
+  });
+  const submitButton = screen.getByRole('button', { name: 'Import Account' });
+
+  return {
+    accountNameField,
+    checkTermsField,
+    entropyField,
+    form,
+    invalidAccountName65,
+    invalidEntropy,
+    invalidPasswordShort,
+    mockUseMobileCoinDValues,
+    passwordConfirmationField,
+    passwordField,
+    submitButton,
+    termsButton,
+    validAccountName64,
+    validEntropy,
+    validPassword99,
+  };
+}
+
+function setupOnSubmit() {
+  // Mocks
+  const mockSetStatus = jest.fn();
+  const mockSetSubmitting = jest.fn();
+  const mockSetErrors = jest.fn();
+  const mockImportAccount = jest.fn();
+
+  // Variables
+  const accountName = 'account name';
+  const entropy = '1111111111111111111111111111111111111111111111111111111111111111';
+  const password = 'password';
+  const isMountedRefTrue = { current: true };
+  const isMountedRefFalse = { current: false };
+  const helpers = {
+    setErrors: mockSetErrors,
+    setStatus: mockSetStatus,
+    setSubmitting: mockSetSubmitting,
+  };
+
+  return {
+    accountName,
+    entropy,
+    helpers,
+    isMountedRefFalse,
+    isMountedRefTrue,
+    mockImportAccount,
+    mockSetErrors,
+    mockSetStatus,
+    mockSetSubmitting,
+    password,
+  };
+}
+
+describe('ImportAccountForm', () => {
+  describe('component', () => {
+    describe('initalValues', () => {
+      test('sets correct initial values', async () => {
+        const { form } = setupComponent();
+        const expectedInitialValues = {
+          accountName: '',
+          checkedTerms: false,
+          entropy: '',
+          password: '',
+          passwordConfirmation: '',
+        };
+
+        expect(form).toHaveFormValues(expectedInitialValues);
+      });
+    });
+
+    describe('validations', () => {
+      test('limits account name to 64 characters.', async () => {
+        const {
+          accountNameField,
+          invalidAccountName65,
+          validAccountName64,
+        } = setupComponent();
+        const expectedErrorMessage = 'Account Name cannot be more than 64 characters.';
+
+        // Fill out with too long account name
+        userEvent.type(accountNameField, invalidAccountName65);
+        userEvent.tab(); // Tab to trigger validations
+
+        // Await because validations are async
+        const errorMessage = await screen.findByText(expectedErrorMessage);
+        await waitFor(() => {
+          expect(errorMessage).toBeInTheDocument();
+        });
+
+        // Clear and use name under the limit
+        userEvent.clear(accountNameField);
+        userEvent.type(accountNameField, validAccountName64);
+        userEvent.tab(); // Tab to trigger validations
+        await waitFor(() => {
+          expect(errorMessage).not.toBeInTheDocument();
+        });
+      });
+
+      test('requires a valid entropy of 64 hexadecimals', async () => {
+        const { entropyField, invalidEntropy, validEntropy } = setupComponent();
+        const expectedHexErrorMessage = 'A valid entropy is 64 hexadecimals.';
+        const expectedRequiredErrorMessage = 'Entropy is required';
+        // Fill out with too long account name
+        userEvent.type(entropyField, invalidEntropy);
+        userEvent.tab(); // Tab to trigger validations
+
+        // Await because validations are async
+        const errorHexMessage = await screen.findByText(
+          expectedHexErrorMessage,
+        );
+        await waitFor(() => {
+          expect(errorHexMessage).toBeInTheDocument();
+        });
+
+        // Clear to show required error
+        userEvent.clear(entropyField);
+        // Await because validations are async
+        const requiredErrorMessage = await screen.findByText(
+          expectedRequiredErrorMessage,
+        );
+        await waitFor(() => {
+          expect(requiredErrorMessage).toBeInTheDocument();
+        });
+
+        // Write valid entropy
+        userEvent.type(entropyField, validEntropy);
+        await waitFor(() => {
+          expect(errorHexMessage).not.toBeInTheDocument();
+          expect(requiredErrorMessage).not.toBeInTheDocument();
+        });
+      });
+
+      test('checkbox is disabled until reading terms', async () => {
+        const {
+          checkTermsField,
+          termsButton,
+        } = setupComponent();
+        const expectedTermsMessage = 'You must read the Terms of Use before using the wallet.';
+
+        // The checkbox is diabled until user has read terms
+        expect(checkTermsField.value).toBe('false');
+        userEvent.click(checkTermsField);
+        expect(checkTermsField.value).toBe('false');
+
+        const termsMessage = await screen.findByText(expectedTermsMessage);
+        await waitFor(() => {
+          expect(termsMessage).toBeInTheDocument();
+        });
+
+        // Reading the terms removes message and allows you to click terms
+        userEvent.click(termsButton);
+        await waitFor(() => {
+          expect(termsMessage).not.toBeInTheDocument();
+        });
+        userEvent.click(checkTermsField);
+        expect(checkTermsField.value).toBe('true');
+      });
+
+      test('password is required and must be between 8 and 99 characters', async () => {
+        const {
+          passwordField,
+          validPassword99,
+          invalidPasswordShort,
+        } = setupComponent();
+        const expectedShortErrorMessage = 'Password must be at least 8 characters in length.';
+        const expectedRequiredErrorMessage = 'Password is required';
+        const expectedLongErrorMessage = 'Passwords cannot be more than 99 characters.';
+
+        // Type up to 1 short from valid and check error
+        userEvent.type(passwordField, invalidPasswordShort);
+        userEvent.tab(); // Tab to trigger validations
+
+        // Await because validations are async
+        const shortErrorMessage = await screen.findByText(
+          expectedShortErrorMessage,
+        );
+        await waitFor(() => {
+          expect(shortErrorMessage).toBeInTheDocument();
+        });
+
+        // Add a character to become valid
+        userEvent.type(passwordField, '1');
+        userEvent.tab(); // Tab to trigger validations
+        await waitFor(() => {
+          expect(shortErrorMessage).not.toBeInTheDocument();
+        });
+
+        // Clear to show required error
+        userEvent.clear(passwordField);
+        // Await because validations are async
+        const requiredErrorMessage = await screen.findByText(
+          expectedRequiredErrorMessage,
+        );
+        await waitFor(() => {
+          expect(requiredErrorMessage).toBeInTheDocument();
+          expect(shortErrorMessage).not.toBeInTheDocument();
+        });
+
+        // Write a password at maximum valid length + 1
+        userEvent.type(passwordField, validPassword99);
+        userEvent.type(passwordField, '1');
+        userEvent.tab(); // Tab to trigger validations
+        // Await because validations are async
+        const longErrorMessage = await screen.findByText(
+          expectedLongErrorMessage,
+        );
+        await waitFor(() => {
+          expect(longErrorMessage).toBeInTheDocument();
+          expect(shortErrorMessage).not.toBeInTheDocument();
+          expect(requiredErrorMessage).not.toBeInTheDocument();
+        });
+
+        // Finally, backspace to become valid again
+        userEvent.type(passwordField, '{backspace}1');
+        await waitFor(() => {
+          expect(longErrorMessage).not.toBeInTheDocument();
+          expect(shortErrorMessage).not.toBeInTheDocument();
+          expect(requiredErrorMessage).not.toBeInTheDocument();
+        });
+      });
+
+      test('password confirmation is required and must match password', async () => {
+        const {
+          passwordConfirmationField,
+          passwordField,
+          validPassword99,
+        } = setupComponent();
+        const expectedMustMatchMessage = 'Must match Password';
+        const expectedRequiredErrorMessage = 'Password Confirmation is required';
+
+        // Type different passwords and password confirmations
+        userEvent.type(passwordField, validPassword99);
+        userEvent.type(
+          passwordConfirmationField,
+          'something completely different',
+        );
+        userEvent.tab(); // Tab to trigger validations
+        // Await because validations are async
+        const mustMatchErrorMessage = await screen.findByText(
+          expectedMustMatchMessage,
+        );
+        await waitFor(() => {
+          expect(mustMatchErrorMessage).toBeInTheDocument();
+        });
+
+        // Clear password confirmation to get error
+        userEvent.clear(passwordConfirmationField);
+        userEvent.tab(); // Tab to trigger validations
+        // Await because validations are async
+        const requiredErrorMessage = await screen.findByText(
+          expectedRequiredErrorMessage,
+        );
+        await waitFor(() => {
+          expect(requiredErrorMessage).toBeInTheDocument();
+        });
+
+        // Type matching confirmation to dismiss errors
+        userEvent.type(passwordConfirmationField, validPassword99);
+        userEvent.tab(); // Tab to trigger validations
+        await waitFor(() => {
+          expect(requiredErrorMessage).not.toBeInTheDocument();
+          expect(mustMatchErrorMessage).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('submit', () => {
+      test('calls importAccount hook with a password and accountName', async () => {
+        const {
+          accountNameField,
+          checkTermsField,
+          entropyField,
+          mockUseMobileCoinDValues,
+          passwordConfirmationField,
+          passwordField,
+          termsButton,
+          submitButton,
+          validAccountName64,
+          validEntropy,
+          validPassword99,
+        } = setupComponent();
+
+        // First tests that the button is disabled
+        expect(submitButton).toBeDisabled();
+        userEvent.click(submitButton);
+        await waitFor(() => {
+          expect(mockUseMobileCoinDValues.importAccount).not.toBeCalled();
+        });
+
+        // Enter valid form information
+        userEvent.type(accountNameField, validAccountName64);
+        userEvent.type(entropyField, validEntropy);
+        userEvent.type(passwordField, validPassword99);
+        userEvent.type(passwordConfirmationField, validPassword99);
+        userEvent.click(termsButton);
+        userEvent.click(checkTermsField);
+        expect(accountNameField.value).toBe(validAccountName64);
+        expect(passwordField.value).toBe(validPassword99);
+        expect(passwordConfirmationField.value).toBe(validPassword99);
+        expect(checkTermsField.value).toBe('true');
+
+        // Submit
+        await waitFor(() => {
+          expect(submitButton).not.toBeDisabled();
+        });
+        userEvent.click(submitButton);
+
+        await waitFor(() => {
+          expect(mockUseMobileCoinDValues.importAccount).toBeCalledWith(
+            validAccountName64,
+            validEntropy,
+            validPassword99,
+          );
+        });
+      });
+
+      test('displays error when thrown', async () => {
+        const expectedErrorMessage = 'I am an error!';
+        const {
+          accountNameField,
+          checkTermsField,
+          entropyField,
+          mockUseMobileCoinDValues,
+          passwordConfirmationField,
+          passwordField,
+          termsButton,
+          submitButton,
+          validAccountName64,
+          validEntropy,
+          validPassword99,
+        } = setupComponent();
+        // @ts-ignore mock
+        mockUseMobileCoinDValues.importAccount.mockImplementation(() => {
+          throw new Error(expectedErrorMessage);
+        });
+
+        // Enter valid form information & Submit
+        userEvent.type(accountNameField, validAccountName64);
+        userEvent.type(entropyField, validEntropy);
+        userEvent.type(passwordField, validPassword99);
+        userEvent.type(passwordConfirmationField, validPassword99);
+        userEvent.click(termsButton);
+        userEvent.click(checkTermsField);
+        userEvent.click(submitButton);
+
+        await waitFor(() => {
+          expect(screen.getByText(expectedErrorMessage)).toBeInTheDocument();
+        });
+      });
+    });
+  });
+
+  describe('functions', () => {
+    // CBB: I don't like this. But I want to make sure that the correct
+    // hooks are being set with the different scenarios.
+    describe('importAccountFormOnSubmit', () => {
+      test('calls importAccount and helpers when mounted', async () => {
+        const {
+          accountName,
+          entropy,
+          helpers,
+          isMountedRefTrue,
+          mockImportAccount,
+          password,
+        } = setupOnSubmit();
+
+        const pseudoProps = {
+          importAccount: mockImportAccount,
+          isMountedRef: isMountedRefTrue,
+        };
+        const values = { accountName, entropy, password };
+        // @ts-ignore mock
+        await importAccountFormOnSubmit(pseudoProps, values, helpers);
+
+        expect(mockImportAccount).toBeCalledWith(accountName, entropy, password);
+        expect(helpers.setStatus).toBeCalledWith({ success: true });
+        expect(helpers.setSubmitting).toBeCalledWith(false);
+        expect(helpers.setErrors).not.toBeCalled();
+      });
+
+      test('calls importAccount and but not helpers when unmounted', async () => {
+        const {
+          accountName,
+          entropy,
+          helpers,
+          isMountedRefFalse,
+          mockImportAccount,
+          password,
+        } = setupOnSubmit();
+
+        const pseudoProps = {
+          importAccount: mockImportAccount,
+          isMountedRef: isMountedRefFalse,
+        };
+        const values = { accountName, entropy, password };
+
+        // @ts-ignore mock
+        await importAccountFormOnSubmit(pseudoProps, values, helpers);
+
+        expect(helpers.setStatus).not.toBeCalled();
+        expect(helpers.setSubmitting).not.toBeCalled();
+      });
+
+      test('correctly sets helpers when call fails whem mounted', async () => {
+        const {
+          accountName,
+          entropy,
+          helpers,
+          isMountedRefTrue,
+          mockImportAccount,
+          password,
+        } = setupOnSubmit();
+
+        const errorMessage = 'error message.';
+        mockImportAccount.mockRejectedValueOnce(new Error(errorMessage));
+        const pseudoProps = {
+          importAccount: mockImportAccount,
+          isMountedRef: isMountedRefTrue,
+        };
+        const values = { accountName, entropy, password };
+
+        // @ts-ignore mock
+        await importAccountFormOnSubmit(pseudoProps, values, helpers);
+        expect(mockImportAccount).toBeCalled();
+
+        expect(helpers.setStatus).toBeCalledWith({ success: false });
+        expect(helpers.setSubmitting).toBeCalledWith(false);
+        expect(helpers.setErrors).toBeCalledWith({ submit: errorMessage });
+      });
+
+      test('does not call helpers when call fails when unmounted', async () => {
+        const {
+          accountName,
+          entropy,
+          helpers,
+          isMountedRefFalse,
+          mockImportAccount,
+          password,
+        } = setupOnSubmit();
+
+        const errorMessage = 'error message.';
+        mockImportAccount.mockRejectedValueOnce(new Error(errorMessage));
+        const pseudoProps = {
+          importAccount: mockImportAccount,
+          isMountedRef: isMountedRefFalse,
+        };
+        const values = { accountName, entropy, password };
+
+        // @ts-ignore mock
+        await importAccountFormOnSubmit(pseudoProps, values, helpers);
+
+        expect(helpers.setStatus).not.toBeCalled();
+        expect(helpers.setSubmitting).not.toBeCalled();
+        expect(helpers.setErrors).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/test/views/auth/ImportAccountView/ImportAccountView.test.tsx
+++ b/test/views/auth/ImportAccountView/ImportAccountView.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { MobileCoinDContextValue } from '../../../../app/contexts/MobileCoinDContext';
+import { ImportAccountView } from '../../../../app/views/auth';
+import renderSnapshot from '../../../renderSnapshot';
+
+jest.mock('../../../../app/hooks/useMobileCoinD');
+
+function setupComponent(contextOverides?: MobileCoinDContextValue) {
+  // Default Context
+  const defaultContext = {
+    encryptedEntropy: 'existing encrypted entropy',
+    isAuthenticated: false,
+  };
+
+  const { asFragment } = renderSnapshot(
+    <ImportAccountView isTest />,
+    {
+      ...defaultContext,
+      ...contextOverides,
+    },
+  );
+
+  // Render Elements
+  const createButton = screen.getByRole('button', {
+    name: 'Create account instead',
+  });
+  const overwriteWarningQuery = screen.queryAllByTestId('overwrite-warning');
+
+  return {
+    asFragment,
+    createButton,
+    overwriteWarningQuery,
+  };
+}
+
+describe('ImportAccountView', () => {
+  describe('component', () => {
+    test('it navigates to ImportAccountView with button click', () => {
+      const { createButton } = setupComponent();
+
+      expect(createButton).toBeInTheDocument();
+
+      userEvent.click(createButton);
+
+      expect(createButton).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('CreateAccountView'),
+      ).toBeInTheDocument();
+    });
+
+    describe('unlock warning', () => {
+      test('when there is an existing user, it renders the warning', () => {
+        const { overwriteWarningQuery } = setupComponent();
+
+        expect(overwriteWarningQuery.length).toBe(1);
+      });
+
+      test('warning allow you to navigate to unlock wallet', () => {
+        setupComponent();
+        const unlockButton = screen.getByRole('button', {
+          name: 'Unlock this wallet',
+        });
+
+        userEvent.click(unlockButton);
+
+        expect(unlockButton).not.toBeInTheDocument();
+        expect(
+          screen.getByTestId('UnlockWalletView'),
+        ).toBeInTheDocument();
+      });
+
+      test('it does not render warning without existing user', () => {
+        // @ts-ignore mock
+        const { overwriteWarningQuery } = setupComponent({ encryptedEntropy: undefined });
+
+        expect(overwriteWarningQuery.length).toBe(0);
+      });
+    });
+
+    describe('render', () => {
+      test('it renders correctly', () => {
+        const { asFragment } = setupComponent();
+        expect(asFragment()).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/test/views/auth/ImportAccountView/__snapshots__/ImportAccountView.test.tsx.snap
+++ b/test/views/auth/ImportAccountView/__snapshots__/ImportAccountView.test.tsx.snap
@@ -1,0 +1,278 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ImportAccountView component render it renders correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root MuiBox-root makeStyles-root"
+    data-testid="ImportAccountView"
+  >
+    <div
+      class="MuiContainer-root makeStyles-viewContainer MuiContainer-maxWidthSm"
+    >
+      <svg
+        class="makeStyles-logoIcon"
+        color="#A6AAB4"
+        fill="none"
+        height="35"
+        viewBox="0 0 141 35"
+        width="141"
+      >
+        <path
+          d="M44.887 18.642l-4.397-6.15V23.74h-2.245V7.837h1.38l5.59 7.858 5.308-7.858h1.403V23.74h-2.268V12.702l-3.953 5.823-.818.117zM64.929 21.191a5.058 5.058 0 01-2 2.105c-.865.499-1.875.749-3.028.749-1.138 0-2.133-.25-2.982-.749-.85-.499-1.5-1.2-1.953-2.105-.452-.904-.678-1.949-.678-3.133 0-1.17.234-2.206.702-3.11a5.083 5.083 0 011.987-2.106c.858-.499 1.863-.748 3.017-.748 1.138 0 2.132.25 2.982.748.85.5 1.504 1.2 1.965 2.105.46.905.69 1.95.69 3.134 0 1.169-.235 2.206-.702 3.11zm-2.538-.21c.616-.764.932-1.723.947-2.877 0-1.216-.296-2.202-.888-2.958-.593-.756-1.412-1.135-2.456-1.135-1.029 0-1.851.383-2.467 1.146-.616.765-.932 1.723-.947 2.877 0 1.216.296 2.202.888 2.958.593.757 1.411 1.134 2.456 1.134 1.029 0 1.851-.381 2.467-1.146zM75.144 12.842c.85.5 1.5 1.205 1.953 2.117.452.912.678 1.976.678 3.192 0 1.17-.234 2.199-.702 3.087a5.046 5.046 0 01-1.988 2.07c-.857.491-1.847.737-2.97.737-.39 0-.846-.082-1.368-.246a5.39 5.39 0 01-1.485-.736l-.445.678h-1.262V7.488L69.8 7.23v5.566c.42-.218.837-.39 1.251-.514.412-.125.775-.188 1.087-.188 1.154 0 2.155.25 3.005.748zm-.55 8.174c.592-.74.889-1.688.889-2.842 0-1.247-.293-2.252-.877-3.016-.585-.764-1.408-1.146-2.468-1.146-.92 0-1.699.272-2.338.818v6.525c.655.515 1.434.772 2.338.772 1.045 0 1.863-.37 2.456-1.111zM80.61 10.364c-.39 0-.718-.137-.983-.41a1.371 1.371 0 01-.397-.994c0-.39.132-.72.397-.994.265-.272.593-.409.982-.409.39 0 .725.137 1.006.41.28.272.42.604.42.993 0 .39-.14.722-.42.994-.281.273-.616.41-1.006.41zm-1.1 13.376V12.398h2.269V23.74H79.51zM84.335 23.74V7.487l2.245-.258V23.74h-2.245zM98.927 18.572h-8.044c.093 1.108.448 1.98 1.064 2.62.615.639 1.531.958 2.747.958.592 0 1.11-.074 1.555-.222.445-.148 1.064-.41 1.86-.784l.702 1.638c-1.373.826-2.745 1.239-4.116 1.239-1.98 0-3.5-.538-4.56-1.614-1.061-1.075-1.591-2.525-1.591-4.35 0-1.169.218-2.205.655-3.11.436-.904 1.064-1.606 1.883-2.105.818-.499 1.78-.748 2.888-.748 1.637 0 2.872.55 3.707 1.649.834 1.099 1.25 2.506 1.25 4.22v.609zm-7.998-1.52h5.823c-.296-2.026-1.247-3.04-2.853-3.04-.858 0-1.54.269-2.047.806-.506.539-.814 1.283-.923 2.234zM112.023 8.47l-.701 1.613c-.702-.25-1.271-.421-1.708-.515-.436-.093-.998-.14-1.684-.14-.967 0-1.844.269-2.63.807-.788.538-1.408 1.297-1.86 2.28-.452.982-.678 2.097-.678 3.344 0 1.154.198 2.21.596 3.169.398.959.975 1.719 1.731 2.28.756.561 1.641.842 2.654.842 1.31 0 2.471-.234 3.485-.702l.865 1.684c-.515.265-1.185.487-2.012.666-.826.18-1.574.27-2.244.27-1.575 0-2.92-.363-4.034-1.088a6.84 6.84 0 01-2.526-2.947c-.569-1.24-.853-2.623-.853-4.15 0-1.591.307-3.021.923-4.292.616-1.27 1.497-2.268 2.643-2.994 1.146-.725 2.475-1.087 3.987-1.087.562 0 1.247.082 2.058.246.811.164 1.474.402 1.988.713zM123.108 21.191a5.069 5.069 0 01-2 2.105c-.865.499-1.875.749-3.029.749-1.138 0-2.132-.25-2.982-.749a4.941 4.941 0 01-1.952-2.105c-.453-.904-.679-1.949-.679-3.133 0-1.17.234-2.206.702-3.11a5.076 5.076 0 011.988-2.106c.857-.499 1.862-.748 3.016-.748 1.139 0 2.132.25 2.982.748.85.5 1.505 1.2 1.965 2.105.459.905.69 1.95.69 3.134 0 1.169-.234 2.206-.701 3.11zm-2.538-.21c.616-.764.932-1.723.947-2.877 0-1.216-.296-2.202-.888-2.958-.593-.756-1.411-1.135-2.456-1.135-1.028 0-1.851.383-2.467 1.146-.616.765-.932 1.723-.947 2.877 0 1.216.296 2.202.889 2.958.592.757 1.41 1.134 2.455 1.134 1.029 0 1.851-.381 2.467-1.146zM126.644 10.364c-.389 0-.717-.137-.982-.41a1.372 1.372 0 01-.397-.994c0-.39.132-.72.397-.994.265-.272.593-.409.982-.409s.725.137 1.005.41c.282.272.422.604.422.993 0 .39-.14.722-.422.994-.28.273-.615.41-1.005.41zm-1.099 13.376V12.398h2.268V23.74h-2.268zM132.508 23.74h-2.244V12.398h1.567l.397 1.496a8.144 8.144 0 012.059-1.344c.763-.351 1.52-.527 2.268-.527 1.231 0 2.147.383 2.747 1.146.6.764.901 1.793.901 3.087v7.484h-2.245v-7.273c0-.826-.137-1.454-.41-1.883-.272-.428-.76-.643-1.461-.643-.53 0-1.108.168-1.731.503-.623.335-1.239.768-1.848 1.298v7.998zM17.5 35C7.85 35 0 27.15 0 17.5S7.85 0 17.5 0 35 7.85 35 17.5 27.15 35 17.5 35zm8.473-21.16a2.28 2.28 0 01-4.112 1.36H2.9c-.118.75-.179 1.518-.179 2.3 0 8.15 6.63 14.78 14.78 14.78 5.968 0 11.121-3.556 13.452-8.66H13.495a2.28 2.28 0 11-.077-2.719h18.467c.259-1.093.395-2.23.395-3.4 0-8.15-6.63-14.78-14.78-14.78-6.388 0-11.842 4.073-13.902 9.758h18.263a2.28 2.28 0 014.112 1.36z"
+          fill="#A6AAB4"
+        />
+      </svg>
+      <div
+        class="MuiPaper-root MuiCard-root makeStyles-cardContainer MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-h2 MuiTypography-paragraph"
+        >
+          Import Account
+        </p>
+        <p
+          class="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-paragraph"
+        >
+          Import an existing account for this desktop wallet.
+        </p>
+        <p
+          class="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-paragraph"
+        >
+          This option is best for individuals who already have MobileCoin accounts. If you do not have an account, please create a new account instead.
+        </p>
+        <div
+          class="MuiBox-root MuiBox-root"
+          data-testid="overwrite-warning"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-paragraph"
+          >
+            It appears that this wallet is locked with an encrypted Entropy. Importing an account will override the wallet. Please ensure that you have secured your Entropy if you wish to change accounts.
+          </p>
+          <a
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary"
+            href="/"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Unlock this wallet
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </a>
+        </div>
+        <form
+          action="#"
+          name="ImportAccountFormName"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+              data-shrink="false"
+              for="ImportAccountForm-accountNameField"
+              id="ImportAccountForm-accountNameField-label"
+            >
+              Account Name (optional)
+            </label>
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiInput-input"
+                id="ImportAccountForm-accountNameField"
+                name="accountName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense"
+              data-shrink="false"
+              for="ImportAccountForm-entropyField"
+              id="ImportAccountForm-entropyField-label"
+            >
+              Entropy
+            </label>
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                id="ImportAccountForm-entropyField"
+                name="entropy"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense"
+              data-shrink="false"
+              for="ImportAccountForm-passwordField"
+              id="ImportAccountForm-passwordField-label"
+            >
+              Password
+            </label>
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                id="ImportAccountForm-passwordField"
+                name="password"
+                type="password"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense"
+              data-shrink="false"
+              for="ImportAccountForm-passwordConfirmationField"
+              id="ImportAccountForm-passwordConfirmationField-label"
+            >
+              Password Confirmation
+            </label>
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                id="ImportAccountForm-passwordConfirmationField"
+                name="passwordConfirmation"
+                type="password"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root MuiBox-root"
+          >
+            <div
+              class="MuiBox-root MuiBox-root"
+            >
+              <div
+                class="MuiBox-root MuiBox-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-displayInline"
+                >
+                  I have read and accept the
+                </p>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label"
+                  >
+                    Terms of Use
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <span
+                aria-disabled="true"
+                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiCheckbox-indeterminate PrivateSwitchBase-disabled MuiCheckbox-disabled MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+                tabindex="-1"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <input
+                    class="PrivateSwitchBase-input"
+                    data-indeterminate="true"
+                    disabled=""
+                    name="checkedTerms"
+                    type="checkbox"
+                    value="false"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10H7v-2h10v2z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+          <p
+            class="MuiFormHelperText-root MuiFormHelperText-focused"
+          >
+            You must read the Terms of Use before using the wallet.
+          </p>
+          <div
+            class="MuiBox-root MuiBox-root makeStyles-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disabled MuiButton-fullWidth MuiButtonBase-disabled"
+              data-testid="submit-button"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Import Account
+              </span>
+            </button>
+          </div>
+        </form>
+        <div
+          class="MuiBox-root MuiBox-root"
+        >
+          <hr
+            class="MuiDivider-root"
+          />
+        </div>
+        <a
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedSecondary"
+          href="/create"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            Create account instead
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </a>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Soundtrack of this PR: [Anderson .Paak & The Free Nationals - Bubblin [LIVE @ SiriusXM]](https://www.youtube.com/watch?v=Qa_RMfx7pVA)

### Motivation

This is 2 of 3 PRs to fully test our auth views. These go into the feature branch `increase-test-coverage-auth-views`.

### In this PR

- Cleaned up some things in CreateAccountView
- Cleaned up ImportAccountForm with tests
- Cleaned up ImportAccountView with tests

### Future Work

- I'll repeat myself a few times here. We'll need to, eventually, formalized test environment setup. Right now, `renderSnapshot` is out of hand (and growing).
- I also think we should move the `isTest` prop into a context and hook pattern.

### Screen Shots

I'll add snapshots to the feature branch PR