### PR TITLE
Test MobilecoindDirectory

### DIFF
--- a/test/views/wallet/ConfigureMobilecoindView/MobilecoindDirectory.test.tsx
+++ b/test/views/wallet/ConfigureMobilecoindView/MobilecoindDirectory.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import useMobilecoindConfigs from '../../../../app/hooks/useMobilecoindConfigs';
+import MobilecoindDirectory from '../../../../app/views/wallet/ConfigureMobilecoindView/MobilecoindDirectory';
+
+jest.mock('../../../../app/hooks/useMobilecoindConfigs');
+
+describe('MobilecoindDirectory', () => {
+  const mockUseMobilecoindConfigs = useMobilecoindConfigs as jest.MockedFunction<
+    typeof useMobilecoindConfigs
+  >;
+
+  // @ts-ignore mock
+  mockUseMobilecoindConfigs.mockImplementation(() => {
+    return {
+      ledgerDbPath: 'ledger/db/path',
+      mobilecoindDbPath: 'mobilecoin/db/path',
+    };
+  });
+  test('MobilecoindDirectory renders view and displays correct ledgerDbPath', () => {
+    render(<MobilecoindDirectory />);
+    expect(screen.getByText('ledger/db/path')).toBeInTheDocument();
+  });
+
+  test('MobilecoindDirectory renders view and displays correct mobilecoindDbPath', () => {
+    render(<MobilecoindDirectory />);
+    expect(screen.getByText('mobilecoin/db/path')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Soundtrack of this PR: [Damian 'Jr. Gong' Marley: NPR Music Tiny Desk Concert](https://www.youtube.com/watch?v=id28fCyYgIU)

### Motivation

Continued test coverage expansion for Desktop Wallet components, views, utils and hooks.

### In this PR

- MobilecoindDirectory renders view and displays correct ledgerDbPath
- MobilecoindDirectory renders view and displays correct mobilecoindDbPath

### Testing

 PASS  test/views/wallet/ConfigureMobilecoindView/MobilecoindDirectory.test.tsx (7.104 s)

File                                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------------------------------|---------|----------|---------|---------|-------------------
All files                              |   18.18 |        0 |    5.88 |   18.18 |                   
 hooks                                 |    7.69 |      100 |       0 |    7.69 |                   
  useMobilecoindConfigs.ts             |    7.69 |      100 |       0 |    7.69 | 6-27              
 utils                                 |   11.76 |        0 |       0 |   11.76 |                   
  LocalStore.ts                        |   11.76 |        0 |       0 |   11.76 | 48-112            
 views/wallet/ConfigureMobilecoindView |     100 |      100 |     100 |     100 |                   
  MobilecoindDirectory.tsx             |     100 |      100 |     100 |     100 |                   

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        8.922 s