### PR TITLE
Test WalletGuard

### DIFF
--- a/app/components/UnlockWalletGuard.tsx
+++ b/app/components/UnlockWalletGuard.tsx
@@ -14,7 +14,7 @@ interface UnlockWalletGuardProps {
 const UnlockWalletGuard: FC<UnlockWalletGuardProps> = ({ children }) => {
   const { encryptedEntropy, isAuthenticated } = useMobileCoinD();
 
-  if (!encryptedEntropy) {
+  if (!encryptedEntropy || !isAuthenticated) {
     return <Redirect to={routePaths.CREATE} />;
   }
 

--- a/app/components/WalletGuard.tsx
+++ b/app/components/WalletGuard.tsx
@@ -12,9 +12,9 @@ interface WalletGuardProps {
 }
 
 const WalletGuard: FC<WalletGuardProps> = ({ children }) => {
-  const { isAuthenticated } = useMobileCoinD();
+  const { isAuthenticated, encryptedEntropy } = useMobileCoinD();
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated || !encryptedEntropy) {
     return <Redirect to={routePaths.ROOT} />;
   }
 

--- a/test/components/UnlockWalletGuard/UnlockWalletGuard.test.tsx
+++ b/test/components/UnlockWalletGuard/UnlockWalletGuard.test.tsx
@@ -57,6 +57,7 @@ describe('UnlockWalletGuard', () => {
   // @ts-ignore mock
     const { children } = setupComponent({ encryptedEntropy: 'entropy' });
 
-    expect(children).toBeInTheDocument();
+    expect(screen.queryByText('Create a new account for this desktop wallet.')).toBeInTheDocument();
+    expect(children).not.toBeInTheDocument();
   });
 });

--- a/test/components/WalletGuard/WalletGuard.test.tsx
+++ b/test/components/WalletGuard/WalletGuard.test.tsx
@@ -10,6 +10,7 @@ jest.mock('../../../app/hooks/useMobileCoinD');
 
 function setupComponent(contextOverides?: MobileCoinDContextValue) {
   const defaultContext = {
+    encryptedEntropy: null,
     isAuthenticated: false,
   };
 
@@ -28,11 +29,11 @@ function setupComponent(contextOverides?: MobileCoinDContextValue) {
   };
 }
 
-// -------------------
 describe('WalletGuard', () => {
   test('authenticated users are given access to children prop of WalletGuard', () => {
     // @ts-ignore mock
     const { success } = setupComponent({
+      encryptedEntropy: 'string',
       isAuthenticated: true,
     });
     expect(success).toBeInTheDocument();
@@ -41,6 +42,47 @@ describe('WalletGuard', () => {
   test('unauthenticated users are redirected to UnlockWalletView', () => {
     const { success } = setupComponent();
     expect(success).not.toBeInTheDocument();
-    expect(screen.queryByTestId('UnlockWalletView')).toBeInTheDocument();
+    // expect(screen.queryByTestId('DashboardOverview')).toBeInTheDocument(); ???
+    // expect(screen.queryByTestId('UnlockWalletView')).toBeInTheDocument(); ???
+    // IF ROUTEPATHS.ROOT GOES TO UNLOCKWALLETVIEW WHICH HAS UNLOCKWALLETGUARD
+    // THEN HAVING NO ENTROPY TAKES PRESCEDENCE OVER BEING UNAUTHENTICATED
+    // USER WILL BE REDIRECTED TO ROUTEPATHS.CREATE, NOT UNLOCKWALLETVIEW OR DASHBOARD OVERVIEW
+
+    // 2 DIFF ROUTEPATHS.ROOT ---> DASHBOARD AND UNLOCKWALLETVIEW
   });
 });
+
+// if you are authenticated you should always also have an encrypted entropy),
+// ------------
+
+
+// test('unauthenticated with no entropy string', () => {
+//   const { children } = setupComponent();
+
+//   expect(screen.queryByText('Create a new account for this desktop wallet.')).toBeInTheDocument();
+//   expect(children).not.toBeInTheDocument();
+// });
+
+// test('authenticated with no entropy string', () => {
+// // @ts-ignore mock
+//   const { children } = setupComponent({ encryptedEntropy: null, isAuthenticated: true });
+
+//   expect(screen.queryByTestId('DashboardOverview')).not.toBeInTheDocument();
+//   expect(children).not.toBeInTheDocument();
+// });
+
+// test('authenticated with entropy string', () => {
+// // @ts-ignore mock
+//   const { children } = setupComponent({ encryptedEntropy: 'entropy', isAuthenticated: true });
+
+//   expect(screen.queryByTestId('DashboardOverview')).toBeInTheDocument();
+//   expect(children).not.toBeInTheDocument();
+// });
+
+// test('unauthenticated with entropy string', () => {
+// // @ts-ignore mock
+//   const { children } = setupComponent({ encryptedEntropy: 'entropy' });
+
+//   expect(children).toBeInTheDocument();
+// });
+// });

--- a/test/components/WalletGuard/WalletGuard.test.tsx
+++ b/test/components/WalletGuard/WalletGuard.test.tsx
@@ -39,50 +39,30 @@ describe('WalletGuard', () => {
     expect(success).toBeInTheDocument();
   });
 
-  test('unauthenticated users are redirected to UnlockWalletView', () => {
+  test('unauthenticated users are redirected to CreateAccountView', () => {
     const { success } = setupComponent();
     expect(success).not.toBeInTheDocument();
-    // expect(screen.queryByTestId('DashboardOverview')).toBeInTheDocument(); ???
-    // expect(screen.queryByTestId('UnlockWalletView')).toBeInTheDocument(); ???
-    // IF ROUTEPATHS.ROOT GOES TO UNLOCKWALLETVIEW WHICH HAS UNLOCKWALLETGUARD
-    // THEN HAVING NO ENTROPY TAKES PRESCEDENCE OVER BEING UNAUTHENTICATED
-    // USER WILL BE REDIRECTED TO ROUTEPATHS.CREATE, NOT UNLOCKWALLETVIEW OR DASHBOARD OVERVIEW
 
-    // 2 DIFF ROUTEPATHS.ROOT ---> DASHBOARD AND UNLOCKWALLETVIEW
+    expect(screen.queryByText('Create a new account for this desktop wallet.')).toBeInTheDocument();
+  });
+
+  test('authenticated users with no encryptedEntropy are redirected to CreateAccountView', () => {
+    // @ts-ignore mock
+    const { success } = setupComponent({
+      isAuthenticated: true,
+    });
+    expect(success).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Create a new account for this desktop wallet.')).toBeInTheDocument();
+  });
+
+  test('unauthenticated users with encyrptedEntropy are redirected to CreateAccountView', () => {
+    // @ts-ignore mock
+    const { success } = setupComponent({
+      encryptedEntropy: 'entropy',
+    });
+    expect(success).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Create a new account for this desktop wallet.')).toBeInTheDocument();
   });
 });
-
-// if you are authenticated you should always also have an encrypted entropy),
-// ------------
-
-
-// test('unauthenticated with no entropy string', () => {
-//   const { children } = setupComponent();
-
-//   expect(screen.queryByText('Create a new account for this desktop wallet.')).toBeInTheDocument();
-//   expect(children).not.toBeInTheDocument();
-// });
-
-// test('authenticated with no entropy string', () => {
-// // @ts-ignore mock
-//   const { children } = setupComponent({ encryptedEntropy: null, isAuthenticated: true });
-
-//   expect(screen.queryByTestId('DashboardOverview')).not.toBeInTheDocument();
-//   expect(children).not.toBeInTheDocument();
-// });
-
-// test('authenticated with entropy string', () => {
-// // @ts-ignore mock
-//   const { children } = setupComponent({ encryptedEntropy: 'entropy', isAuthenticated: true });
-
-//   expect(screen.queryByTestId('DashboardOverview')).toBeInTheDocument();
-//   expect(children).not.toBeInTheDocument();
-// });
-
-// test('unauthenticated with entropy string', () => {
-// // @ts-ignore mock
-//   const { children } = setupComponent({ encryptedEntropy: 'entropy' });
-
-//   expect(children).toBeInTheDocument();
-// });
-// });

--- a/test/components/WalletGuard/WalletGuard.test.tsx
+++ b/test/components/WalletGuard/WalletGuard.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { WalletGuard } from '../../../app/components';
+import { MobileCoinDContextValue } from '../../../app/contexts/MobileCoinDContext';
+import renderSnapshot from '../../renderSnapshot';
+
+jest.mock('../../../app/hooks/useMobileCoinD');
+
+function setupComponent(contextOverides?: MobileCoinDContextValue) {
+  const defaultContext = {
+    isAuthenticated: false,
+  };
+
+  renderSnapshot(
+    <WalletGuard>success</WalletGuard>,
+    {
+      ...defaultContext,
+      ...contextOverides,
+    },
+  );
+
+  const success = screen.queryByText(/success/i);
+
+  return {
+    success,
+  };
+}
+
+// -------------------
+describe('WalletGuard', () => {
+  test('authenticated users are given access to children prop of WalletGuard', () => {
+    // @ts-ignore mock
+    const { success } = setupComponent({
+      isAuthenticated: true,
+    });
+    expect(success).toBeInTheDocument();
+  });
+
+  test('unauthenticated users are redirected to UnlockWalletView', () => {
+    const { success } = setupComponent();
+    expect(success).not.toBeInTheDocument();
+    expect(screen.queryByTestId('UnlockWalletView')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Soundtrack of this PR: [Kodak Black - Calling My Spirit [Official Music Video]](https://www.youtube.com/watch?v=ppSY98RGyBU)

### Motivation

Continued test coverage expansion for Desktop Wallet components, views, utils and hooks.

### In this PR

- Testing view renders for authenticated and unauthenticated users
- Testing appropriate child prop renders for an authenticated user
- Updated tests to check for auth scenarios with and without entropy. 
- Updated UnlockWalletGuard and WalletGuard to redirect users to CreateAccountView if they are missing either auth or entropy

### Testing
 PASS  test/components/WalletGuard/WalletGuard.test.tsx (7.596 s)
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------|---------|----------|---------|---------|-------------------
WalletGuard.tsx                              |     100 |      100 |     100 |     100 |       

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        12.38 s
