### PR TITLE
Auth views added to enUS

### DIFF
--- a/app/views/auth/CreateAccountView/CreateAccountForm.tsx
+++ b/app/views/auth/CreateAccountView/CreateAccountForm.tsx
@@ -7,6 +7,7 @@ import {
 import { Formik, Form, Field } from 'formik';
 import type { FormikHelpers } from 'formik';
 import { Checkbox, TextField } from 'formik-material-ui';
+import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 
 import { SubmitButton, TermsOfUseDialog } from '../../../components';
@@ -63,6 +64,7 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
 }: CreateAccountFormProps) => {
   const isMountedRef = useIsMountedRef();
   const { createAccount } = useMobileCoinD();
+  const { t } = useTranslation('CreateAccountForm');
 
   const [canCheck, setCanCheck] = React.useState(false);
   const [open, setOpen] = React.useState(false);
@@ -97,20 +99,20 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
   const validationSchema = Yup.object().shape({
     accountName: Yup.string().max(
       64,
-      'Account Name cannot be more than 64 characters.',
+      t('accountNameValidation'),
     ),
     // CBB: It appears that the checkedTerms error message is not working properly.
     checkedTerms: Yup.bool().oneOf(
       [true],
-      'You must accept Terms of Use to use wallet.',
+      t('checkedTermsValidation'),
     ),
     password: Yup.string()
-      .min(8, 'Password must be at least 8 characters in length.')
-      .max(99, 'Passwords cannot be more than 99 characters.')
-      .required('Password is required'),
+      .min(8, t('passwordMin'))
+      .max(99, t('passwordMax'))
+      .required(t('passwordRequired')),
     passwordConfirmation: Yup.string()
-      .oneOf([Yup.ref('password')], 'Must match Password')
-      .required('Password Confirmation is required'),
+      .oneOf([Yup.ref('password')], t('passwordConfirmationRef'))
+      .required(t('passwordConfirmationRequired')),
   });
 
   return (
@@ -130,14 +132,14 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
               id="CreateAccountForm-accountNameField"
               component={TextField}
               fullWidth
-              label="Account Name (optional)"
+              label={t('nameLabel')}
               name="accountName"
             />
             <Field
               id="CreateAccountForm-passwordField"
               component={TextField}
               fullWidth
-              label="Password"
+              label={t('passwordLabel')}
               margin="dense"
               name="password"
               type="password"
@@ -146,7 +148,7 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
               id="CreateAccountForm-passwordConfirmationField"
               component={TextField}
               fullWidth
-              label="Password Confirmation"
+              label={t('passwordConfirmationLabel')}
               margin="dense"
               name="passwordConfirmation"
               type="password"
@@ -159,10 +161,10 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
               >
                 <Box>
                   <Typography display="inline">
-                    I have read and accept the
+                    {t('acceptTerms')}
                   </Typography>
                   <Button color="primary" onClick={handleClickOpen}>
-                    Terms of Use
+                    {t('acceptTermsButton')}
                   </Button>
                 </Box>
                 <Field
@@ -176,7 +178,7 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
             </Box>
             {!canCheck && (
               <FormHelperText focused>
-                You must read the Terms of Use before using the wallet.
+                {t('acceptTermsFormHelper')}
               </FormHelperText>
             )}
             {errors.submit && (
@@ -189,7 +191,7 @@ const CreateAccountForm: FC<CreateAccountFormProps> = ({
               onClick={submitForm}
               isSubmitting={isSubmitting}
             >
-              Create Account
+              {t('createAccountButton')}
             </SubmitButton>
             <TermsOfUseDialog open={open} handleCloseTerms={handleCloseTerms} />
           </Form>

--- a/app/views/auth/CreateAccountView/index.tsx
+++ b/app/views/auth/CreateAccountView/index.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
   makeStyles,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
 import LogoIcon from '../../../components/icons/LogoIcon';
@@ -55,6 +56,7 @@ const useStyles = makeStyles((theme: Theme) => {
 const CreateAccountView: FC<CreateAccountViewProps> = ({ isTest }: CreateAccountViewProps) => {
   const classes = useStyles();
   const { encryptedEntropy } = useMobileCoinD();
+  const { t } = useTranslation('CreateAccountView');
 
   return (
     <Box data-testid="CreateAccountView" className={classes.root}>
@@ -62,29 +64,25 @@ const CreateAccountView: FC<CreateAccountViewProps> = ({ isTest }: CreateAccount
         <LogoIcon className={classes.logoIcon} />
         <Card className={classes.cardContainer}>
           <Typography color="textPrimary" variant="h2" paragraph>
-            Create Account
+            {t('title')}
           </Typography>
           <Typography variant="body2" color="textSecondary" paragraph>
-            Create a new account for this desktop wallet.
+            {t('header')}
           </Typography>
           <Typography variant="body2" color="textSecondary" paragraph>
-            This option is best for individuals who do not have an existing
-            account. If you have an account you would like to use, please import
-            an existing account instead.
+            {t('description')}
           </Typography>
           {encryptedEntropy && (
             <Box data-testid="overwrite-warning">
               <Typography variant="body2" paragraph>
-                It appears that this wallet is locked with an encrypted Entropy.
-                Creating an account will override the wallet. Please ensure that
-                you have secured your Entropy if you wish to change accounts.
+                {t('overwriteWarning')}
               </Typography>
               <Button
                 color="secondary"
                 component={RouterLink}
                 to={routePaths.ROOT}
               >
-                Unlock this wallet
+                {t('unlockWalletButton')}
               </Button>
             </Box>
           )}
@@ -101,7 +99,7 @@ const CreateAccountView: FC<CreateAccountViewProps> = ({ isTest }: CreateAccount
             to={routePaths.IMPORT}
             variant="outlined"
           >
-            Import account instead
+            {t('importInstead')}
           </Button>
         </Card>
       </Container>

--- a/app/views/auth/ImportAccountView/ImportAccountForm.tsx
+++ b/app/views/auth/ImportAccountView/ImportAccountForm.tsx
@@ -7,6 +7,7 @@ import {
 import { Formik, Form, Field } from 'formik';
 import type { FormikHelpers } from 'formik';
 import { Checkbox, TextField } from 'formik-material-ui';
+import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 
 import { SubmitButton, TermsOfUseDialog } from '../../../components';
@@ -64,6 +65,7 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
 }: ImportAccountFormProps) => {
   const isMountedRef = useIsMountedRef();
   const { importAccount } = useMobileCoinD();
+  const { t } = useTranslation('ImportAccountForm');
 
   const [canCheck, setCanCheck] = React.useState(false);
   const [open, setOpen] = React.useState(false);
@@ -99,23 +101,23 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
   const validationSchema = Yup.object().shape({
     accountName: Yup.string().max(
       64,
-      'Account Name cannot be more than 64 characters.',
+      t('accountNameValidation'),
     ),
     // CBB: It appears that the checkedTerms error message is not working properly.
     checkedTerms: Yup.bool().oneOf(
       [true],
-      'You must accept Terms of Use to use wallet.',
+      t('checkedTermsValidation'),
     ),
     entropy: Yup.string()
-      .matches(/^[0-9a-f]{64}$/i, 'A valid entropy is 64 hexadecimals.')
-      .required('Entropy is required'),
+      .matches(/^[0-9a-f]{64}$/i, t('entropyMatches'))
+      .required(t('entropyRequired')),
     password: Yup.string()
-      .min(8, 'Password must be at least 8 characters in length.')
-      .max(99, 'Passwords cannot be more than 99 characters.')
-      .required('Password is required'),
+      .min(8, t('passwordMin'))
+      .max(99, t('passwordMax'))
+      .required(t('passwordRequired')),
     passwordConfirmation: Yup.string()
-      .oneOf([Yup.ref('password')], 'Must match Password')
-      .required('Password Confirmation is required'),
+      .oneOf([Yup.ref('password')], t('passwordConfirmationRef'))
+      .required(t('passwordConfirmationRequired')),
   });
 
   return (
@@ -135,14 +137,14 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
               id="ImportAccountForm-accountNameField"
               component={TextField}
               fullWidth
-              label="Account Name (optional)"
+              label={t('nameLabel')}
               name="accountName"
             />
             <Field
               id="ImportAccountForm-entropyField"
               component={TextField}
               fullWidth
-              label="Entropy"
+              label={t('entropyLabel')}
               margin="dense"
               name="entropy"
             />
@@ -150,7 +152,7 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
               id="ImportAccountForm-passwordField"
               component={TextField}
               fullWidth
-              label="Password"
+              label={t('passwordLabel')}
               margin="dense"
               name="password"
               type="password"
@@ -159,7 +161,7 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
               id="ImportAccountForm-passwordConfirmationField"
               component={TextField}
               fullWidth
-              label="Password Confirmation"
+              label={t('passwordConfirmationLabel')}
               margin="dense"
               name="passwordConfirmation"
               type="password"
@@ -172,10 +174,10 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
               >
                 <Box>
                   <Typography display="inline">
-                    I have read and accept the
+                    {t('acceptTerms')}
                   </Typography>
                   <Button color="primary" onClick={handleClickOpen}>
-                    Terms of Use
+                    {t('acceptTermsButton')}
                   </Button>
                 </Box>
                 <Field
@@ -189,7 +191,7 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
             </Box>
             {!canCheck && (
               <FormHelperText focused>
-                You must read the Terms of Use before using the wallet.
+                {t('acceptTermsFormHelper')}
               </FormHelperText>
             )}
             {errors.submit && (
@@ -202,7 +204,7 @@ const ImportAccountForm: FC<ImportAccountFormProps> = ({
               onClick={submitForm}
               isSubmitting={isSubmitting}
             >
-              Import Account
+              {t('importAccountButton')}
             </SubmitButton>
             <TermsOfUseDialog open={open} handleCloseTerms={handleCloseTerms} />
           </Form>

--- a/app/views/auth/ImportAccountView/index.tsx
+++ b/app/views/auth/ImportAccountView/index.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
   makeStyles,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
 import LogoIcon from '../../../components/icons/LogoIcon';
@@ -55,6 +56,7 @@ const ImportAccountView: FC<ImportAccountViewProps> = ({
 }: ImportAccountViewProps) => {
   const classes = useStyles();
   const { encryptedEntropy } = useMobileCoinD();
+  const { t } = useTranslation('ImportAccountView');
 
   return (
     <Box data-testid="ImportAccountView" className={classes.root}>
@@ -62,30 +64,25 @@ const ImportAccountView: FC<ImportAccountViewProps> = ({
         <LogoIcon className={classes.logoIcon} />
         <Card className={classes.cardContainer}>
           <Typography variant="h2" paragraph>
-            Import Account
+            {t('title')}
           </Typography>
           <Typography variant="body2" color="textSecondary" paragraph>
-            Import an existing account for this desktop wallet.
+            {t('header')}
           </Typography>
           <Typography variant="body2" color="textSecondary" paragraph>
-            This option is best for individuals who already have MobileCoin
-            accounts. If you do not have an account, please create a new account
-            instead.
+            {t('description')}
           </Typography>
           {encryptedEntropy && (
             <Box data-testid="overwrite-warning">
               <Typography variant="body2" paragraph>
-                It appears that this wallet is locked with an encrypted Entropy.
-                Importing an account will override the wallet. Please ensure
-                that you have secured your Entropy if you wish to change
-                accounts.
+                {t('overwriteWarning')}
               </Typography>
               <Button
                 color="secondary"
                 component={RouterLink}
                 to={routePaths.ROOT}
               >
-                Unlock this wallet
+                {t('unlockWalletButton')}
               </Button>
             </Box>
           )}
@@ -102,7 +99,7 @@ const ImportAccountView: FC<ImportAccountViewProps> = ({
             to={routePaths.CREATE}
             variant="outlined"
           >
-            Create account instead
+            {t('createInstead')}
           </Button>
         </Card>
       </Container>

--- a/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
+++ b/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
@@ -5,6 +5,7 @@ import { Box, FormHelperText } from '@material-ui/core';
 import { Formik, Form, Field } from 'formik';
 import type { FormikHelpers } from 'formik';
 import { TextField } from 'formik-material-ui';
+import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 
 import { SubmitButton } from '../../../components';
@@ -55,6 +56,7 @@ const UnlockWalletForm: FC<UnlockWalletFormProps> = ({
 }: UnlockWalletFormProps) => {
   const isMountedRef = useIsMountedRef();
   const { unlockWallet } = useMobileCoinD();
+  const [t] = useTranslation('UnlockWalletForm');
 
   const handleOnSubmit = async (
     values: UnlockWalletFormValues,
@@ -70,7 +72,7 @@ const UnlockWalletForm: FC<UnlockWalletFormProps> = ({
   };
 
   const validationSchema = Yup.object().shape({
-    password: Yup.string().required('Password is required'),
+    password: Yup.string().required(t('pwRequired')),
   });
 
   return (
@@ -89,7 +91,7 @@ const UnlockWalletForm: FC<UnlockWalletFormProps> = ({
               id="passwordField"
               component={TextField}
               fullWidth
-              label="Password"
+              label={t('pwLabel')}
               name="password"
               type="password"
             />
@@ -103,7 +105,7 @@ const UnlockWalletForm: FC<UnlockWalletFormProps> = ({
               isSubmitting={isSubmitting}
               onClick={submitForm}
             >
-              Unlock Wallet
+              {t('unlockWalletButton')}
             </SubmitButton>
           </Form>
         );

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -9,5 +9,14 @@
     "pwRequired": "Password is required",
     "pwLabel": "Password",
     "unlockWalletButton": "Unlock Wallet"
+  },
+
+  "ImportAccountView": {
+    "title": "Import Account",
+    "header": "Import an existing account for this desktop wallet.",
+    "description": "This option is best for individuals who already have MobileCoin accounts. If you do not have an account, please create a new account instead.",
+    "overwriteWarning": "It appears that this wallet is locked with an encrypted Entropy. Importing an account will override the wallet. Please ensure that you have secured your Entropy if you wish to change accounts.",
+    "unlockWalletButton": "Unlock this wallet",
+    "createInstead": "Create account instead"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -38,5 +38,14 @@
     "acceptTermsButton": "Terms of Use",
     "acceptTermsFormHelper": "You must read the Terms of Use before using the wallet.",
     "importAccountButton": "Import Account"
+  },
+
+  "CreateAccountView": {
+    "title": "Create Account",
+    "header": "Create a new account for this desktop wallet.",
+    "description": "This option is best for individuals who do not have an existing account. If you have an account you would like to use, please import an existing account instead.",
+    "overwriteWarning": "It appears that this wallet is locked with an encrypted Entropy. Creating an account will override the wallet. Please ensure that you have secured your Entropy if you wish to change accounts.",
+    "unlockWalletButton": "Unlock this wallet",
+    "importInstead": "Import account instead"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -47,5 +47,22 @@
     "overwriteWarning": "It appears that this wallet is locked with an encrypted Entropy. Creating an account will override the wallet. Please ensure that you have secured your Entropy if you wish to change accounts.",
     "unlockWalletButton": "Unlock this wallet",
     "importInstead": "Import account instead"
+  },
+
+  "CreateAccountForm": {
+    "accountNameValidation": "Account Name cannot be more than 64 characters.",
+    "checkedTermsValidation": "You must accept Terms of Use to use wallet.",
+    "passwordMin": "Password must be at least 8 characters in length.",
+    "passwordMax": "Passwords cannot be more than 99 characters.",
+    "passwordRequired": "Password is required",
+    "passwordConfirmationRef": "Must match Password",
+    "passwordConfirmationRequired": "Password Confirmation is required",
+    "nameLabel": "Account Name (optional)",
+    "passwordLabel": "Password",
+    "passwordConfirmationLabel": "Password Confirmation",
+    "acceptTerms": "I have read and accept the",
+    "acceptTermsButton": "Terms of Use",
+    "acceptTermsFormHelper": "You must read the Terms of Use before using the wallet.",
+    "createAccountButton": "Create Account"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -18,5 +18,25 @@
     "overwriteWarning": "It appears that this wallet is locked with an encrypted Entropy. Importing an account will override the wallet. Please ensure that you have secured your Entropy if you wish to change accounts.",
     "unlockWalletButton": "Unlock this wallet",
     "createInstead": "Create account instead"
+  },
+
+  "ImportAccountForm": {
+    "accountNameValidation": "Account Name cannot be more than 64 characters.",
+    "checkedTermsValidation": "You must accept Terms of Use to use wallet.",
+    "entropyMatches": "A valid entropy is 64 hexadecimals.",
+    "entropyRequired": "Entropy is required",
+    "passwordMin": "Password must be at least 8 characters in length.",
+    "passwordMax": "Passwords cannot be more than 99 characters.",
+    "passwordRequired": "Password is required",
+    "passwordConfirmationRef": "Must match Password",
+    "passwordConfirmationRequired": "Password Confirmation is required",
+    "nameLabel": "Account Name (optional)",
+    "entropyLabel": "Entropy",
+    "passwordLabel": "Password",
+    "passwordConfirmationLabel": "Password Confirmation",
+    "acceptTerms": "I have read and accept the",
+    "acceptTermsButton": "Terms of Use",
+    "acceptTermsFormHelper": "You must read the Terms of Use before using the wallet.",
+    "importAccountButton": "Import Account"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -3,5 +3,11 @@
     "description": "Please enter the passphrase you used to secure your wallet. If you cannot recall your passphrase, you may re-import the account into your wallet using their Entropy seed.",
     "importInstead": "Import account from Entropy instead",
     "title": "Unlock Wallet"
+  },
+
+  "UnlockWalletForm": {
+    "pwRequired": "Password is required",
+    "pwLabel": "Password",
+    "unlockWalletButton": "Unlock Wallet"
   }
 }


### PR DESCRIPTION
Soundtrack of this PR: [Future - Never Stop](https://www.youtube.com/watch?v=nNS3ye93eZA)

### Motivation

Prepping app for multiple languages by replacing copy with keys instead of strings. `enUS` doc will house all of the apps default copy for ease of translation implementations.

### In this PR
Auth directories added:
  - CreateAccountView
  - ImportAccountView
  - UnlockWalletView

### Future Work
To be added :
- Errors
- Wallet
- Components