### PR TITLE
Add DashboardView, GiftingView and AccountCard component

### DIFF
--- a/app/components/AccountCard.tsx
+++ b/app/components/AccountCard.tsx
@@ -13,6 +13,7 @@ import {
 } from '@material-ui/core';
 import clsx from 'clsx';
 import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
 
 import type { Theme } from '../theme';
 import type Account from '../types/Account';
@@ -64,6 +65,7 @@ const AccountCard: FC<AccountCardProps> = ({
   const [isQRCode, setIsQRCode] = useState(false);
   const classes = useStyles();
   const { enqueueSnackbar } = useSnackbar();
+  const { t } = useTranslation('AccountCard');
 
   const { b58Code, mobUrl, name } = account;
 
@@ -72,8 +74,8 @@ const AccountCard: FC<AccountCardProps> = ({
       clipboard.writeText(code);
       enqueueSnackbar(
         isGift
-          ? 'Gift Code copied to clipboard!'
-          : 'Address Code copied to clipboard!',
+          ? t('clipboardGift')
+          : t('clipboardAddress'),
         {
           variant: 'success',
         },
@@ -87,9 +89,9 @@ const AccountCard: FC<AccountCardProps> = ({
 
   let headerString = '';
   if (isQRCode) {
-    headerString = isGift ? 'Gift QR Code' : 'Account QR Code';
+    headerString = isGift ? t('giftQR') : t('accountQR');
   } else {
-    headerString = isGift ? 'Gift Code' : 'Account Address Code';
+    headerString = isGift ? t('giftHeader') : t('accountHeader');
   }
 
   return (
@@ -110,7 +112,7 @@ const AccountCard: FC<AccountCardProps> = ({
               <LogoIcon />
               <Tooltip
                 title={
-                  isQRCode ? 'Show Account Address Code' : 'Show MobURL QR Code'
+                  isQRCode ? t('accountTooltip') : t('mobUrlTooltip')
                 }
                 placement="right"
                 arrow
@@ -140,7 +142,7 @@ const AccountCard: FC<AccountCardProps> = ({
                 />
               ) : (
                 <Tooltip
-                  title="Click to copy to clipboard."
+                  title={t('copyTooltip')}
                   placement="right"
                   arrow
                 >
@@ -163,7 +165,7 @@ const AccountCard: FC<AccountCardProps> = ({
                 color="textSecondary"
                 variant="h4"
               >
-                {name || 'Unnamed Account'}
+                {name || t('unnamed')}
               </Typography>
               <Typography
                 data-testid="account-card-short-code"

--- a/app/views/wallet/DashboardView/BalanceIndicator.tsx
+++ b/app/views/wallet/DashboardView/BalanceIndicator.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { FC } from 'react';
 
 import { Box, makeStyles, Typography } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import { MOBNumberFormat } from '../../../components';
 import { MOBIcon } from '../../../components/icons';
@@ -36,11 +37,12 @@ const BalanceIndicator: FC<BalanceProps> = ({
   isSynced,
 }: BalanceProps) => {
   const classes = useStyles();
+  const { t } = useTranslation('BalanceIndicator');
 
   return (
     <Box className={classes.item}>
       <Typography variant="h3" color="textSecondary" gutterBottom>
-        Balance
+        {t('title')}
       </Typography>
       <Box className={classes.valueContainer}>
         <MOBIcon className={classes.icon} />
@@ -58,7 +60,7 @@ const BalanceIndicator: FC<BalanceProps> = ({
           variant="h6"
           color="primary"
         >
-          Balance may be out-of-date while wallet syncs with ledger.
+          {t('syncMessage')}
         </Typography>
       )}
     </Box>

--- a/app/views/wallet/DashboardView/CloseWalletModal.tsx
+++ b/app/views/wallet/DashboardView/CloseWalletModal.tsx
@@ -9,6 +9,7 @@ import {
   Modal,
   Typography,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import { SubmitButton } from '../../../components';
 import { Theme } from '../../../theme';
@@ -38,6 +39,7 @@ const useStyles = makeStyles((theme: Theme) => {
 const CloseWalletModal: FC = () => {
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
+  const { t } = useTranslation('CloseWalletModal');
 
   const handleOpenModal = () => {
     setOpen(true);
@@ -60,7 +62,7 @@ const CloseWalletModal: FC = () => {
           isSubmitting={false}
           onClick={handleOpenModal}
         >
-          Close Wallet
+          {t('closeWalletButton')}
         </SubmitButton>
       </Container>
       <Modal
@@ -75,10 +77,10 @@ const CloseWalletModal: FC = () => {
         <Fade in={open}>
           <Box className={classes.paper}>
             <Typography variant="h2" gutterBottom>
-              Close and Secure Wallet?
+              {t('closeVerifyHeader')}
             </Typography>
             <Typography variant="body2" gutterBottom>
-              Are you sure you want to close and secure the wallet?
+              {t('closeVerifyBody')}
             </Typography>
             <Box display="flex">
               <SubmitButton
@@ -88,7 +90,7 @@ const CloseWalletModal: FC = () => {
                 isSubmitting={false}
                 disabled={!open}
               >
-                No, Keep Wallet Open
+                {t('closeVerifyDeny')}
               </SubmitButton>
               <Box p={1} />
               <SubmitButton
@@ -98,7 +100,7 @@ const CloseWalletModal: FC = () => {
                 isSubmitting={false}
                 disabled={!open}
               >
-                Yes, Close Wallet
+                {t('closeVerifyConfirm')}
               </SubmitButton>
             </Box>
           </Box>

--- a/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
+++ b/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
@@ -21,6 +21,7 @@ import {
 import { Formik, Form, Field } from 'formik';
 import { RadioGroup, TextField } from 'formik-material-ui';
 import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 
 import {
@@ -115,6 +116,7 @@ const BuildGiftForm: FC = () => {
     nextBlock,
     submitGiftCode,
   } = useMobileCoinD();
+  const { t } = useTranslation('BuildGiftForm');
 
   // TODO - this isSynced stuff should live in 1 location -- maybe as context state
   let isSynced = false;
@@ -151,7 +153,7 @@ const BuildGiftForm: FC = () => {
     setShowModal(false);
     setIsAwaitingConformation(false);
     setConfirmation(EMPTY_CONFIRMATION);
-    enqueueSnackbar('Gift Canceled', {
+    enqueueSnackbar(t('giftCanceled'), {
       variant: 'warning',
     });
   };
@@ -164,14 +166,14 @@ const BuildGiftForm: FC = () => {
         if (
           confirmation.txProposal === null
           || confirmation.txProposal === undefined
-        ) throw new Error('Could not find confirmation');
+        ) throw new Error(t('confirmationNotFound'));
         await submitGiftCode(confirmation.txProposal, confirmation.giftB58Code);
         if (isMountedRef.current) {
           setStatus({ success: true });
           setSubmittingConfirmedGift(false);
           setIsAwaitingConformation(false);
           setConfirmation(EMPTY_CONFIRMATION);
-          enqueueSnackbar('Gift Created! Your balance will update shortly.', {
+          enqueueSnackbar(t('giftCreated'), {
             variant: 'success',
           });
         }
@@ -182,7 +184,7 @@ const BuildGiftForm: FC = () => {
           setSubmittingConfirmedGift(false);
           setIsAwaitingConformation(false);
           setConfirmation(EMPTY_CONFIRMATION);
-          enqueueSnackbar('Hmm, something went wrong.', {
+          enqueueSnackbar(t('error'), {
             variant: 'error',
           });
         }
@@ -193,7 +195,7 @@ const BuildGiftForm: FC = () => {
   const createAccountLabel = (account: Account) => {
     const name = account.name && account.name.length > 0
       ? `${account.name}: `
-      : 'Unnamed Account: ';
+      : `${t('unnamed')}: `;
     return (
       <Box display="flex" justifyContent="space-between">
         <Typography>
@@ -217,12 +219,12 @@ const BuildGiftForm: FC = () => {
     return (
       <Box pt={2}>
         <FormLabel className={classes.form} component="legend">
-          <Typography color="primary">Select Account</Typography>
+          <Typography color="primary">{t('select')}</Typography>
         </FormLabel>
         <Field component={RadioGroup} name="senderPublicAddress">
           <Box display="flex" justifyContent="space-between">
-            <Typography>Account Name</Typography>
-            <Typography>Account Balance</Typography>
+            <Typography>{t('accountName')}</Typography>
+            <Typography>{t('accountBalance')}</Typography>
           </Box>
           {accounts.map((account: Account) => {
             return (
@@ -251,7 +253,7 @@ const BuildGiftForm: FC = () => {
       const valueAsPicoMob = BigInt(valueString.replace('.', ''));
       if (valueAsPicoMob + fee > selectedBalance) {
         // TODO - probably want to replace this before launch
-        error = 'Please reserve 0.01 MOB for transaction fee.';
+        error = t('errorFee');
       }
       return error;
     };
@@ -275,8 +277,8 @@ const BuildGiftForm: FC = () => {
       }}
       validationSchema={Yup.object().shape({
         mobValue: Yup.number()
-          .positive('A positive, non-zero amount is required to gift MOB.')
-          .required('A positive, non-zero amount is required to gift MOB.'),
+          .positive(t('positiveValidation'))
+          .required(t('positiveValidationRequired')),
       })}
       validateOnMount
       onSubmit={async (
@@ -297,7 +299,7 @@ const BuildGiftForm: FC = () => {
             convertMobStringToPicoMobBigInt(values.mobValue),
             convertMobStringToPicoMobBigInt(values.feeAmount),
           );
-          if (result === null || result === undefined) throw new Error('Could not build gift code.');
+          if (result === null || result === undefined) throw new Error(t('errorBuild'));
 
           const {
             feeConfirmation,
@@ -366,12 +368,12 @@ const BuildGiftForm: FC = () => {
             )}
             <Box pt={4}>
               <FormLabel component="legend">
-                <Typography color="primary">Gift Details</Typography>
+                <Typography color="primary">{t('giftDetails')}</Typography>
               </FormLabel>
               <Field
                 component={TextField}
                 fullWidth
-                label="MOB Amount"
+                label={t('mobLabel')}
                 margin="normal"
                 name="mobValue"
                 id="mobValue"
@@ -399,7 +401,7 @@ const BuildGiftForm: FC = () => {
             {!isSynced && (
               <Box mt={3}>
                 <FormHelperText error>
-                  Wallet must sync with ledger before sending gifts.
+                  {t('errorSyncBeforeSending')}
                 </FormHelperText>
               </Box>
             )}
@@ -408,7 +410,7 @@ const BuildGiftForm: FC = () => {
               onClick={submitForm}
               isSubmitting={isAwaitingConformation || isSubmitting}
             >
-              {isSynced ? 'Create Gift' : 'Wallet syncing...'}
+              {isSynced ? t('createGift') : `${t('walletSyncing')}...`}
             </SubmitButton>
             <Modal
               aria-labelledby="transition-modal-title"
@@ -430,14 +432,18 @@ const BuildGiftForm: FC = () => {
               >
                 <Container className={classes.paper}>
                   <Box py={2}>
-                    <h2 id="transition-modal-title">Gift Confirmation</h2>
+                    <h2 id="transition-modal-title">{t('')}</h2>
                     <p id="transition-modal-description">
-                      Please check and confirm your gift intent:
+                      {t('giftConfirmationDescription')}
+                      :
                     </p>
                   </Box>
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Account Balance:</Typography>
+                    <Typography>
+                      {t('accountBalance')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -452,7 +458,10 @@ const BuildGiftForm: FC = () => {
                   </Box>
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography color="primary">Gift Value:</Typography>
+                    <Typography color="primary">
+                      {t('giftValue')}
+                      :
+                    </Typography>
                     <Typography color="primary">
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -463,7 +472,10 @@ const BuildGiftForm: FC = () => {
                   </Box>
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Fee:</Typography>
+                    <Typography>
+                      {t('fee')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -474,7 +486,10 @@ const BuildGiftForm: FC = () => {
                   </Box>
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Total:</Typography>
+                    <Typography>
+                      {t('total')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -488,7 +503,10 @@ const BuildGiftForm: FC = () => {
                     <Typography>---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Remaining Balance:</Typography>
+                    <Typography>
+                      {t('remaining')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -500,7 +518,7 @@ const BuildGiftForm: FC = () => {
                   <Box py={1} />
                   {/* TODO - after multiple accounts, we should actually store these gift codes. please check jira for full explation */}
                   <Typography variant="body2" color="textPrimary">
-                    MOB will be sent to this gift card after you confirm.
+                    {t('mobWillBeSent')}
                   </Typography>
                   <Box py={1} />
                   {showCode ? (
@@ -509,7 +527,7 @@ const BuildGiftForm: FC = () => {
                       account={{
                         b58Code: confirmation?.giftB58Code,
                         mobUrl: `https://mobileocoin.com/mob58/${confirmation?.giftB58Code}`,
-                        name: 'Gift Code (Pending)',
+                        name: t('pending'),
                       }}
                     />
                   ) : (
@@ -519,7 +537,7 @@ const BuildGiftForm: FC = () => {
                         size="large"
                         onClick={handleShowCode}
                       >
-                        Show Gift Code
+                        {t('showCode')}
                       </Button>
                     </Box>
                   )}
@@ -533,7 +551,7 @@ const BuildGiftForm: FC = () => {
                       fullWidth
                       variant="contained"
                     >
-                      Cancel
+                      {t('cancel')}
                     </Button>
                     <Box px={2} />
                     <Button
@@ -544,7 +562,7 @@ const BuildGiftForm: FC = () => {
                       onClick={handleConfirm(setErrors, setStatus)}
                       variant="contained"
                     >
-                      {showCode ? 'Confirm Gift' : 'Please Secure Code'}
+                      {showCode ? t('confirmGift') : t('secureCode')}
                     </Button>
                   </Box>
                 </Container>

--- a/app/views/wallet/GiftingView/BuildGiftPanel/index.tsx
+++ b/app/views/wallet/GiftingView/BuildGiftPanel/index.tsx
@@ -23,6 +23,7 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
 
 import { AccountCard, MOBNumberFormat } from '../../../../components';
 import ShortCode from '../../../../components/ShortCode';
@@ -60,6 +61,8 @@ const BuildGiftPanel: FC = () => {
     EMPTY_PENDING_DELETE_CODE,
   );
 
+  const { t } = useTranslation('BuildGiftPanel');
+
   const handleDialogOpen = (giftCode: string, giftValue: string) => {
     return () => {
       setDialogOpen(true);
@@ -75,7 +78,7 @@ const BuildGiftPanel: FC = () => {
   const handleCopyClick = (code: string) => {
     return () => {
       clipboard.writeText(code);
-      enqueueSnackbar('Gift Code copied to clipboard!', {
+      enqueueSnackbar(t('giftCodeCopied'), {
         variant: 'success',
       });
     };
@@ -85,7 +88,7 @@ const BuildGiftPanel: FC = () => {
     handleDialogClose();
     try {
       deleteStoredGiftB58Code(pendingDeleteCode[0]);
-      enqueueSnackbar('Deleted!', {
+      enqueueSnackbar(t('deleted'), {
         variant: 'success',
       });
     } catch (err) {
@@ -107,14 +110,11 @@ const BuildGiftPanel: FC = () => {
       >
         <Box>
           <Typography variant="body2" color="textPrimary">
-            You can package and gift your MOB!
+            {t('title')}
           </Typography>
           <Box p={1} />
           <Typography variant="body2" color="textSecondary">
-            Use this form to create redeemable gift codes with MOB inside. To
-            create a gift code, you simply need to input the value you would
-            like to gift. You will then be asked to confirm the contents of the
-            gift and secure the gift&apos;s secret code.
+            {t('description')}
           </Typography>
         </Box>
       </Box>
@@ -125,13 +125,11 @@ const BuildGiftPanel: FC = () => {
         <>
           <Box pt={4}>
             <Typography variant="body2" color="textPrimary">
-              Manage Gift Codes
+              {t('manageGiftCodes')}
             </Typography>
             <Box p={1} />
             <Typography variant="body2" color="textSecondary">
-              When you create a gift, this wallet will store its code and value.
-              You can click to copy at any time. If you do not wish to store the
-              gift code anymore, you can click the trashcan icon to delete.
+              {t('manageGiftCodesDescription')}
             </Typography>
           </Box>
           <Box py={2}>
@@ -139,8 +137,8 @@ const BuildGiftPanel: FC = () => {
               <Table size="small" aria-label="block status">
                 <TableHead component={Paper}>
                   <TableRow>
-                    <TableCell>Shortened Gift Code</TableCell>
-                    <TableCell>Value</TableCell>
+                    <TableCell>{t('shortened')}</TableCell>
+                    <TableCell>{t('value')}</TableCell>
                     <TableCell />
                   </TableRow>
                 </TableHead>
@@ -160,7 +158,7 @@ const BuildGiftPanel: FC = () => {
                         <TableCell align="right">
                           <Box display="flex" justifyContent="flex-end">
                             <Tooltip
-                              title="Click to copy to clipboard."
+                              title={t('clickToCopy')}
                               placement="right"
                               arrow
                             >
@@ -175,7 +173,7 @@ const BuildGiftPanel: FC = () => {
                               </div>
                             </Tooltip>
                             <Tooltip
-                              title="Click to delete gift code."
+                              title={t('clickToDelete')}
                               placement="right"
                               arrow
                             >
@@ -207,11 +205,10 @@ const BuildGiftPanel: FC = () => {
             aria-labelledby="alert-dialog-title"
             aria-describedby="alert-dialog-description"
           >
-            <DialogTitle id="alert-dialog-title">Delete Gift Code?</DialogTitle>
+            <DialogTitle id="alert-dialog-title">{t('deleteDialogTitle')}</DialogTitle>
             <DialogContent>
               <DialogContentText id="alert-dialog-description">
-                If this gift has been claimed, or if you do not want to store
-                the code and value anymore, you can delete code here.
+                {t('deleteDialogDescription')}
               </DialogContentText>
               <AccountCard
                 isGift
@@ -222,7 +219,7 @@ const BuildGiftPanel: FC = () => {
                 }}
               />
               <Box py={2} display="flex" justifyContent="space-between">
-                <Typography color="textPrimary">Gift Value:</Typography>
+                <Typography color="textPrimary">{t('giftValue')}</Typography>
                 <MOBNumberFormat
                   value={pendingDeleteCode[1]}
                   valueUnit="pMOB"
@@ -230,16 +227,15 @@ const BuildGiftPanel: FC = () => {
                 />
               </Box>
               <DialogContentText color="textPrimary">
-                Deleting will not cancel the gift, and a user must claim the
-                gift with the code.
+                {t('deleteDialogText')}
               </DialogContentText>
             </DialogContent>
             <DialogActions>
               <Button onClick={handleDialogClose} color="primary" autoFocus>
-                Cancel
+                {t('cancelButton')}
               </Button>
               <Button onClick={handleConfirmDelete} color="primary">
-                Delete
+                {t('deleteButton')}
               </Button>
             </DialogActions>
           </Dialog>

--- a/app/views/wallet/GiftingView/ConsumeGiftPanel/ConsumeGiftForm.tsx
+++ b/app/views/wallet/GiftingView/ConsumeGiftPanel/ConsumeGiftForm.tsx
@@ -20,6 +20,7 @@ import {
 import { Formik, Form, Field } from 'formik';
 import { RadioGroup, TextField } from 'formik-material-ui';
 import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 
 import { SubmitButton, MOBNumberFormat } from '../../../../components';
@@ -99,6 +100,7 @@ const ConsumeGiftForm: FC = () => {
     b58Code,
     submitTransaction,
   } = useMobileCoinD();
+  const { t } = useTranslation('ConsumeGiftForm');
 
   // We'll use this array in prep for future patterns with multiple accounts
   const mockMultipleAccounts: Array<Account> = [
@@ -113,7 +115,7 @@ const ConsumeGiftForm: FC = () => {
     setShowModal(false);
     setIsAwaitingConformation(false);
     setConfirmation(EMPTY_CONFIRMATION);
-    enqueueSnackbar('Gift Canceled', {
+    enqueueSnackbar(t('giftCanceled'), {
       variant: 'warning',
     });
   };
@@ -126,7 +128,7 @@ const ConsumeGiftForm: FC = () => {
         if (
           confirmation.txProposal === null
           || confirmation.txProposal === undefined
-        ) throw new Error('Could not find confirmation');
+        ) throw new Error(t('confirmationNotFound'));
 
         await submitTransaction(confirmation.txProposal);
         if (isMountedRef.current) {
@@ -134,22 +136,22 @@ const ConsumeGiftForm: FC = () => {
           setSubmittingConfirmedGift(false);
           setIsAwaitingConformation(false);
           setConfirmation(EMPTY_CONFIRMATION);
-          enqueueSnackbar('Gift Received! Your balance will update shortly.', {
+          enqueueSnackbar(t('confirmation'), {
             variant: 'success',
           });
         }
       } catch (err) {
         if (isMountedRef.current) {
           const santitizedError = err.message
-            === '13 INTERNAL: transactions_manager.submit_tx_proposal: Connection(Operation { error: TransactionValidation(ContainsSpentKeyImage), total_delay: 0ns, tries: 1 })'
-            ? 'This gift has already been claimed!'
+            === t('error13')
+            ? t('giftClaimed')
             : err.message;
           setStatus({ success: false });
           setErrors({ submit: santitizedError });
           setSubmittingConfirmedGift(false);
           setIsAwaitingConformation(false);
           setConfirmation(EMPTY_CONFIRMATION);
-          enqueueSnackbar('Hmm, something went wrong.', {
+          enqueueSnackbar(t('error'), {
             variant: 'error',
           });
         }
@@ -160,7 +162,7 @@ const ConsumeGiftForm: FC = () => {
   const createAccountLabel = (account: Account) => {
     const name = account.name && account.name.length > 0
       ? `${account.name}: `
-      : 'Unnamed Account: ';
+      : `${t('unnamed')}: `;
     return (
       <Box display="flex" justifyContent="space-between">
         <Typography>
@@ -184,12 +186,12 @@ const ConsumeGiftForm: FC = () => {
     return (
       <Box pt={2}>
         <FormLabel className={classes.form} component="legend">
-          <Typography color="primary">Select Account</Typography>
+          <Typography color="primary">{t('select')}</Typography>
         </FormLabel>
         <Field component={RadioGroup} name="senderPublicAddress">
           <Box display="flex" justifyContent="space-between">
-            <Typography>Account Name</Typography>
-            <Typography>Account Balance</Typography>
+            <Typography>{t('accountName')}</Typography>
+            <Typography>{t('accountBalance')}</Typography>
           </Box>
           {accounts.map((account: Account) => {
             return (
@@ -222,7 +224,7 @@ const ConsumeGiftForm: FC = () => {
       }}
       validationSchema={Yup.object().shape({
         giftB58Code: Yup.string().required(
-          'You need a valid gift code to open a gift.',
+          t('giftB58Validation'),
         ),
       })}
       validateOnMount
@@ -235,7 +237,7 @@ const ConsumeGiftForm: FC = () => {
         try {
           setIsAwaitingConformation(true);
           const result = await openGiftCode(values.giftB58Code);
-          if (result === null || result === undefined) throw new Error('Could not find gift with code.');
+          if (result === null || result === undefined) throw new Error(t('giftB58Error'));
 
           const {
             feeConfirmation,
@@ -299,12 +301,12 @@ const ConsumeGiftForm: FC = () => {
             )}
             <Box pt={4}>
               <FormLabel component="legend">
-                <Typography color="primary">Gift Details</Typography>
+                <Typography color="primary">{t('giftDetails')}</Typography>
               </FormLabel>
               <Field
                 component={TextField}
                 fullWidth
-                label="Gift Code"
+                label={t('giftCode')}
                 margin="normal"
                 name="giftB58Code"
                 id="giftB58Code"
@@ -321,7 +323,7 @@ const ConsumeGiftForm: FC = () => {
               onClick={submitForm}
               isSubmitting={isAwaitingConformation || isSubmitting}
             >
-              Open Gift
+              {t('openGift')}
             </SubmitButton>
             <Modal
               aria-labelledby="transition-modal-title"
@@ -340,11 +342,14 @@ const ConsumeGiftForm: FC = () => {
               <Slide in={showModal} timeout={{ enter: 0, exit: 0 }}>
                 <Container className={classes.paper}>
                   <Typography variant="h1" id="transition-modal-title">
-                    Gift Confirmation
+                    {t('giftConfirmation')}
                   </Typography>
                   <Box py={2} />
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Account Balance:</Typography>
+                    <Typography>
+                      {t('accountBalance')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -358,7 +363,10 @@ const ConsumeGiftForm: FC = () => {
                     <Typography>---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Total:</Typography>
+                    <Typography>
+                      {t('total')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -368,7 +376,10 @@ const ConsumeGiftForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Fee:</Typography>
+                    <Typography>
+                      {t('fee')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -378,7 +389,10 @@ const ConsumeGiftForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography color="primary">Gift Value:</Typography>
+                    <Typography color="primary">
+                      {t('giftValue')}
+                      :
+                    </Typography>
                     <Typography color="primary">
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -392,7 +406,10 @@ const ConsumeGiftForm: FC = () => {
                     <Typography>---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography color="primary">New Balance:</Typography>
+                    <Typography color="primary">
+                      {t('newBalance')}
+                      :
+                    </Typography>
                     <Typography color="primary">
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -411,7 +428,7 @@ const ConsumeGiftForm: FC = () => {
                       fullWidth
                       variant="contained"
                     >
-                      Cancel
+                      {t('cancel')}
                     </Button>
                     <Box px={2} />
                     <Button
@@ -421,7 +438,7 @@ const ConsumeGiftForm: FC = () => {
                       onClick={handleConfirm(setErrors, setStatus)}
                       variant="contained"
                     >
-                      Claim Gift
+                      {t('claimGift')}
                     </Button>
                   </Box>
                 </Container>

--- a/app/views/wallet/GiftingView/ConsumeGiftPanel/index.tsx
+++ b/app/views/wallet/GiftingView/ConsumeGiftPanel/index.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react';
 import {
   Box, Container, Typography, makeStyles,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import { MOBNumberFormat } from '../../../../components';
 import { MOBIcon } from '../../../../components/icons';
@@ -29,6 +30,7 @@ const useStyles = makeStyles(() => {
 const BuildGiftPanel: FC = () => {
   const classes = useStyles();
   const { balance, networkHighestBlockIndex, nextBlock } = useMobileCoinD();
+  const { t } = useTranslation('ConsumeGiftPanel');
   // TODO consolidate the isSynced logic throughout app to one location.
   // consider using a specifc context when we split the MobileCoinDContext
   const isSynced = nextBlock === null || networkHighestBlockIndex === null
@@ -56,7 +58,7 @@ const BuildGiftPanel: FC = () => {
               variant="overline"
               color="textSecondary"
             >
-              Balance
+              {t('balance')}
             </Typography>
             <Box className={classes.valueContainer}>
               <Box className={classes.mobContainer}>
@@ -71,14 +73,13 @@ const BuildGiftPanel: FC = () => {
             </Box>
             {!isSynced && (
               <Typography variant="h6" color="primary">
-                Balance may be out-of-date while wallet syncs with ledger.
+                {t('syncMessage')}
               </Typography>
             )}
           </Box>
           <Box>
             <Typography variant="body2" color="textSecondary">
-              You may use this form to collect gift codes. Simply enter the Gift
-              Code and confirm you want to consume the gift into your wallet.
+              {t('description')}
             </Typography>
           </Box>
         </Box>

--- a/app/views/wallet/GiftingView/index.tsx
+++ b/app/views/wallet/GiftingView/index.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react';
 import {
   Box, Grid, makeStyles, Tab, Tabs,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import TabPanel from '../../../components/TabPanel';
 import type { Theme } from '../../../theme';
@@ -23,6 +24,7 @@ const useStyles = makeStyles((theme: Theme) => {
 const GiftingView: FC = () => {
   const classes = useStyles();
   const [selectedTabIndex, setSelectedTabIndex] = React.useState(0);
+  const { t } = useTranslation('GiftingView');
 
   const handleChange = (
     _event: React.ChangeEvent<Record<string, unknown>>,
@@ -42,8 +44,8 @@ const GiftingView: FC = () => {
             textColor="secondary"
             onChange={handleChange}
           >
-            <Tab label="Gift MOB" />
-            <Tab label="Open Gift" />
+            <Tab label={t('giftMOB')} />
+            <Tab label={t('openGift')} />
           </Tabs>
           <TabPanel
             panels={[BuildGiftPanel, ConsumeGiftPanel]}

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -144,5 +144,18 @@
   "BalanceIndicator": {
     "title": "Balance",
     "syncMessage": "Balance may be out-of-date while wallet syncs with ledger."
+  },
+
+  "AccountCard": {
+    "clipboardGift": "Gift Code copied to clipboard!",
+    "clipboardAddress": "Address Code copied to clipboard!",
+    "giftQR": "Gift QR Code",
+    "accountQR": "Account QR Code",
+    "giftHeader": "Gift Code",
+    "accountHeader": "Account Address Code",
+    "accountTooltip": "Show Account Address Code",
+    "mobUrlTooltip": "Show MobURL QR Code",
+    "copyTooltip": "Click to copy to clipboard.",
+    "unnamed": "Unnamed Account"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -170,5 +170,24 @@
   "GiftingView": {
     "giftMOB": "Gift MOB",
     "openGift": "Open Gift"
+  },
+
+  "BuildGiftPanel": {
+    "giftCodeCopied": "Gift Code copied to clipboard!",
+    "deleted": "Deleted!",
+    "title": "You can package and gift your MOB!",
+    "description": "Use this form to create redeemable gift codes with MOB inside. To create a gift code, you simply need to input the value you would like to gift. You will then be asked to confirm the contents of the gift and secure the gifts secret code.",
+    "manageGiftCodes": "Manage Gift Codes",
+    "manageGiftCodesDescription": "When you create a gift, this wallet will store its code and value. You can click to copy at any time. If you do not wish to store the gift code anymore, you can click the trashcan icon to delete.",
+    "shortened": "Shortened Gift Code",
+    "value": "Value",
+    "clickToCopy": "Click to copy to clipboard.",
+    "clickToDelete": "Click to delete gift code.",
+    "deleteDialogTitle": "Delete Gift Code?",
+    "deleteDialogDescription": "If this gift has been claimed, or if you do not want to store the code and value anymore, you can delete code here.",
+    "giftValue": "Gift Value:",
+    "deleteDialogText": "Deleting will not cancel the gift, and a user must claim the gift with the code.",
+    "cancelButton": "Cancel",
+    "deleteButton": "Delete"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -157,5 +157,18 @@
     "mobUrlTooltip": "Show MobURL QR Code",
     "copyTooltip": "Click to copy to clipboard.",
     "unnamed": "Unnamed Account"
+  },
+
+  "CloseWalletModal": {
+    "closeWalletButton": "Close Wallet",
+    "closeVerifyHeader": "Close and Secure Wallet?",
+    "closeVerifyBody": "Are you sure you want to close and secure the wallet?",
+    "closeVerifyDeny": "No, Keep Wallet Open",
+    "closeVerifyConfirm": "Yes, Close Wallet"
+  },
+
+  "GiftingView": {
+    "giftMOB": "Gift MOB",
+    "openGift": "Open Gift"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -221,6 +221,11 @@
     "cancel": "Cancel",
     "confirmGift": "Confirm Gift",
     "secureCode": "Please Secure Code"
-  }
+  },
 
+  "ConsumeGiftPanel": {
+    "balance": "Balance",
+    "syncMessage": "Balance may be out-of-date while wallet syncs with ledger.",
+    "description": "You may use this form to collect gift codes. Simply enter the Gift Code and confirm you want to consume the gift into your wallet."
+  }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -227,5 +227,30 @@
     "balance": "Balance",
     "syncMessage": "Balance may be out-of-date while wallet syncs with ledger.",
     "description": "You may use this form to collect gift codes. Simply enter the Gift Code and confirm you want to consume the gift into your wallet."
+  },
+
+  "ConsumeGiftForm": {
+    "giftCanceled": "Gift Canceled",
+    "confirmationNotFound": "Could not find confirmation",
+    "confirmation": "Gift Received! Your balance will update shortly.",
+    "error13": "13 INTERNAL: transactions_manager.submit_tx_proposal: Connection(Operation { error: TransactionValidation(ContainsSpentKeyImage), total_delay: 0ns, tries: 1 })",
+    "giftClaimed": "This gift has already been claimed!",
+    "error": "Hmm, something went wrong.",
+    "unnamed": "Unnamed Account",
+    "select": "Select Account",
+    "accountName": "Account Name",
+    "accountBalance": "Account Balance",
+    "giftB58Validation": "You need a valid gift code to open a gift.",
+    "giftB58Error": "Could not find gift with code.",
+    "giftDetails": "Gift Details",
+    "giftCode": "Gift Code",
+    "openGift": "Open Gift",
+    "giftConfirmation": "Gift Confirmation",
+    "total": "Total",
+    "fee": "Fee",
+    "giftValue": "Gift Value",
+    "newBalance": "New Balance",
+    "cancel": "Cancel",
+    "claimGift": "Claim Gift"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -189,5 +189,38 @@
     "deleteDialogText": "Deleting will not cancel the gift, and a user must claim the gift with the code.",
     "cancelButton": "Cancel",
     "deleteButton": "Delete"
+  },
+
+  "BuildGiftForm": {
+    "giftCanceled": "Gift Canceled",
+    "confirmationNotFound": "Could not find confirmation",
+    "giftCreated": "Gift Created! Your balance will update shortly.",
+    "error": "Hmm, something went wrong.",
+    "unnamed": "Unnamed Account",
+    "select": "Select Account",
+    "accountName": "Account Name",
+    "accountBalance": "Account Balance",
+    "errorFee": "Please reserve 0.01 MOB for transaction fee.",
+    "positiveValidation": "A positive, non-zero amount is required to gift MOB.",
+    "positiveValidationRequired": "A positive, non-zero amount is required to gift MOB.",
+    "errorBuild": "Could not build gift code.",
+    "giftDetails": "Gift Details",
+    "mobLabel": "MOB Amount",
+    "errorSyncBeforeSending": "Wallet must sync with ledger before sending gifts.",
+    "createGift": "Create Gift",
+    "walletSyncing": "Wallet syncing",
+    "giftConfirmation": "Gift Confirmation",
+    "giftConfirmationDescription": "Please check and confirm your gift intent",
+    "giftValue": "Gift Value",
+    "fee": "Fee",
+    "total": "Total",
+    "remaining": "Remaining Balance",
+    "mobWillBeSent": "MOB will be sent to this gift card after you confirm.",
+    "pending": "Gift Code (Pending)",
+    "showCode": "Show Gift Code",
+    "cancel": "Cancel",
+    "confirmGift": "Confirm Gift",
+    "secureCode": "Please Secure Code"
   }
+
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -139,5 +139,10 @@
     "resetLedgerModalDescription": "Resetting the ledger will restart the wallet. You will need to re-sync the ledger from 0. The app will refresh, and you will need to re-enter your password.",
     "cancelButton": "Cancel",
     "confirmButton": "Confirm"
+  },
+
+  "BalanceIndicator": {
+    "title": "Balance",
+    "syncMessage": "Balance may be out-of-date while wallet syncs with ledger."
   }
 }

--- a/test/components/AccountCard/AccountCard.test.tsx
+++ b/test/components/AccountCard/AccountCard.test.tsx
@@ -1,27 +1,35 @@
 import React from 'react';
 
-import { fireEvent, render, screen } from '@testing-library/react';
 import 'jest-canvas-mock';
-import { SnackbarProvider } from 'notistack';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import AccountCard from '../../../app/components/AccountCard';
+import renderSnapshot from '../../renderSnapshot';
 
 const MOCK_LONG_CODE = 'mockLongCode';
 const MOCK_QR_CODE = 'mockQRCode';
 
+function setupComponent(props?) {
+  // @ts-ignore mock
+  renderSnapshot(
+    <AccountCard
+      account={{
+        ...{
+          b58Code: MOCK_LONG_CODE,
+          balance: 'one million',
+          mobUrl: MOCK_QR_CODE,
+        },
+        ...props,
+      }}
+    />,
+  );
+}
+
 describe('AccountCard', () => {
   test('renders long code with tooltip by default and toggles correctly', () => {
-    render(
-      <SnackbarProvider>
-        <AccountCard
-          account={{
-            b58Code: MOCK_LONG_CODE,
-            balance: 'one million',
-            mobUrl: MOCK_QR_CODE,
-          }}
-        />
-      </SnackbarProvider>,
-    );
+    setupComponent();
 
     expect(screen.queryByTestId('account-card-center')).not.toBeNull();
     expect(screen.queryByTestId('long-code-code')).not.toBeNull();
@@ -31,7 +39,7 @@ describe('AccountCard', () => {
     );
     expect(screen.queryByTestId('account-card-qr-code')).toBeNull();
 
-    fireEvent.click(screen.getByTestId('account-card-toggle'));
+    userEvent.click(screen.getByTestId('account-card-toggle'));
 
     expect(screen.queryByTestId('long-code-code')).toBeNull();
     expect(screen.queryByTestId('account-card-tooltip')).toBeNull();
@@ -40,19 +48,7 @@ describe('AccountCard', () => {
 
   test('renders name correctly', () => {
     const mockName = 'timmy';
-
-    render(
-      <SnackbarProvider>
-        <AccountCard
-          account={{
-            b58Code: MOCK_LONG_CODE,
-            balance: 'one million',
-            mobUrl: MOCK_QR_CODE,
-            name: mockName,
-          }}
-        />
-      </SnackbarProvider>,
-    );
+    setupComponent({ name: mockName });
 
     expect(screen.getByTestId('account-card-name').textContent).toEqual(
       mockName,
@@ -60,17 +56,7 @@ describe('AccountCard', () => {
   });
 
   test('renders correct placeholder for unnamed account', () => {
-    render(
-      <SnackbarProvider>
-        <AccountCard
-          account={{
-            b58Code: MOCK_LONG_CODE,
-            balance: 'one million',
-            mobUrl: MOCK_QR_CODE,
-          }}
-        />
-      </SnackbarProvider>,
-    );
+    setupComponent();
 
     expect(screen.getByTestId('account-card-name').textContent).toEqual(
       'Unnamed Account',
@@ -78,23 +64,13 @@ describe('AccountCard', () => {
   });
 
   test('renders correct toggle tooltip', () => {
-    render(
-      <SnackbarProvider>
-        <AccountCard
-          account={{
-            b58Code: MOCK_LONG_CODE,
-            balance: 'one million',
-            mobUrl: MOCK_QR_CODE,
-          }}
-        />
-      </SnackbarProvider>,
-    );
+    setupComponent();
 
     const toggle = screen.getByTestId('account-card-toggle');
 
     expect(toggle).toHaveAttribute('title', 'Show MobURL QR Code');
 
-    fireEvent.click(screen.getByTestId('account-card-toggle'));
+    userEvent.click(screen.getByTestId('account-card-toggle'));
 
     expect(toggle).toHaveAttribute('title', 'Show Account Address Code');
   });


### PR DESCRIPTION
Soundtrack of this PR: [Outkast - Chronomentrophobia](https://www.youtube.com/watch?v=PCLiU-a-d00)

### Motivation

Prepping app for multiple languages by replacing copy with keys instead of strings. `enUS` doc will house all of the apps default copy for ease of translation implementations.

### In this PR
Directories added:
- DashboardView
- GiftingView
- AccountCard component

### Review Request:
- ConsumeGiftPanel being exported as BuildGiftPanel, no issues being caused from what I can tell. Should we update and hope nothing breaks?

### Future Work
To be added :
- Wallet Views
- Components