### PR TITLE
Add remaining views for globalization 

### DIFF
--- a/app/views/wallet/PrivacyPolicyView/index.tsx
+++ b/app/views/wallet/PrivacyPolicyView/index.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   makeStyles,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { PrivacyPolicy } from '../../../components';
@@ -70,6 +71,7 @@ const useStyles = makeStyles((theme: Theme) => {
 
 const PrivacyPolicyView: FC = () => {
   const classes = useStyles();
+  const { t } = useTranslation('PrivacyPolicyView');
 
   return (
     <Container className={classes.cardContainer} maxWidth="md">
@@ -79,9 +81,9 @@ const PrivacyPolicyView: FC = () => {
           to={routePaths.APP_SETTINGS}
           component={RouterLink}
         >
-          <Typography color="textSecondary">Settings</Typography>
+          <Typography color="textSecondary">{t('settings')}</Typography>
         </Link>
-        <Typography color="textPrimary">Privacy Policy</Typography>
+        <Typography color="textPrimary">{t('privacyPolicy')}</Typography>
       </Breadcrumbs>
       <Box my={3}>
         <PrivacyPolicy />

--- a/app/views/wallet/RetrieveEntropyView/ShowRetrievedEntropyModal.tsx
+++ b/app/views/wallet/RetrieveEntropyView/ShowRetrievedEntropyModal.tsx
@@ -13,6 +13,7 @@ import {
   Modal,
   Typography,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import type { Theme } from '../../../theme';
 
@@ -52,6 +53,7 @@ const ShowRetrievedEntropyModal: FC<ShowRetrievedEntropyModalProps> = ({
 }: ShowRetrievedEntropyModalProps) => {
   const classes = useStyles();
   const [showEntropy, setShowEntropy] = useState(false);
+  const { t } = useTranslation('ShowRetrievedEntropyModal');
 
   // TODO, i should start making a single util for all of this coercing logic
   const toggleEntropy = () => {
@@ -81,13 +83,11 @@ const ShowRetrievedEntropyModal: FC<ShowRetrievedEntropyModalProps> = ({
       <Fade in={open}>
         <Box className={classes.paper} display="flex" flexDirection="column">
           <Typography color="textPrimary" gutterBottom variant="h2">
-            This is your secret Entropy!
+            {t('header')}
           </Typography>
           <br />
           <Typography variant="body2" color="textSecondary">
-            We decrypted your Entropy and will now show you the code on your
-            screen. Please store this code in a secure, private manner. You will
-            need your Entropy to import this account into other wallets.
+            {t('description')}
           </Typography>
           <br />
 
@@ -107,8 +107,8 @@ const ShowRetrievedEntropyModal: FC<ShowRetrievedEntropyModalProps> = ({
                     size="small"
                   >
                     {showEntropy
-                      ? 'Hide Secret Entropy'
-                      : 'Show Secret Entropy'}
+                      ? t('hide')
+                      : t('show')}
                   </Fab>
                 </Box>
                 {showEntropy ? (
@@ -140,7 +140,7 @@ const ShowRetrievedEntropyModal: FC<ShowRetrievedEntropyModalProps> = ({
             type="submit"
             variant="contained"
           >
-            I have secured my Entropy
+            {t('secured')}
           </Button>
         </Box>
       </Fade>

--- a/app/views/wallet/RetrieveEntropyView/index.tsx
+++ b/app/views/wallet/RetrieveEntropyView/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '@material-ui/core';
 import { Formik, Form, Field } from 'formik';
 import { TextField } from 'formik-material-ui';
+import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 import * as Yup from 'yup';
 
@@ -84,6 +85,7 @@ const RetrieveEntropyView: FC = () => {
   const handleCloseModal = () => {
     setEntropy(null);
   };
+  const { t } = useTranslation('RetrieveEntropyView');
 
   return (
     <Container className={classes.cardContainer} maxWidth="sm">
@@ -93,9 +95,9 @@ const RetrieveEntropyView: FC = () => {
           to={routePaths.APP_SETTINGS}
           component={RouterLink}
         >
-          <Typography color="textSecondary">Settings</Typography>
+          <Typography color="textSecondary">{t('settings')}</Typography>
         </Link>
-        <Typography color="textPrimary">Retrieve Secret Entropy</Typography>
+        <Typography color="textPrimary">{t('retrieveSecret')}</Typography>
       </Breadcrumbs>
       <Box
         alignItems="center"
@@ -106,28 +108,23 @@ const RetrieveEntropyView: FC = () => {
       >
         <Box>
           <Typography variant="body2" display="inline" color="textSecondary">
-            Your Entropy is the
+            {t('header')}
           </Typography>
           <Typography variant="body2" display="inline" color="primary">
             {' SECRET KEY '}
           </Typography>
           <Typography variant="body2" display="inline" color="textSecondary">
-            that unlocks your wallet and allows you to use MobileCoin. It is
-            unique to your account. It is important that you never share this
-            code. You may wish to use this code in a secure, safe manner. This
-            wallet uses your password to store an encrypted Entropy.
+            {t('description')}
           </Typography>
         </Box>
         <br />
         <Typography variant="body2" color="textSecondary">
-          The Entropy can be used to import your wallet in case your device is
-          damaged or lost. It allows you to add your account to other wallets.
+          {t('entropyCanBeUsed')}
         </Typography>
         <br />
 
         <Typography variant="body2" color="textSecondary">
-          If you have forgotten or misplaced your Entropy, you may retrieve here
-          with your password.
+          {t('misplacedYourEntropy')}
         </Typography>
       </Box>
       <Box flexGrow={1} mt={3}>
@@ -138,7 +135,7 @@ const RetrieveEntropyView: FC = () => {
             submit: null,
           }}
           validationSchema={Yup.object().shape({
-            password: Yup.string().required('Password is required'),
+            password: Yup.string().required(t('passwordRequired')),
           })}
           validateOnMount
           onSubmit={async (
@@ -152,7 +149,7 @@ const RetrieveEntropyView: FC = () => {
 
               const entropyString = await retrieveEntropy(values.password);
 
-              if (typeof entropyString !== 'string') throw new Error('Something went wrong.');
+              if (typeof entropyString !== 'string') throw new Error(t('error'));
               if (isMountedRef.current) {
                 setStatus({ success: true });
                 setSubmitting(false);
@@ -175,12 +172,12 @@ const RetrieveEntropyView: FC = () => {
               <Form>
                 <Box pt={4}>
                   <FormLabel component="legend">
-                    <Typography color="primary">Retrieve Entropy</Typography>
+                    <Typography color="primary">{t('retrieveEntropy')}</Typography>
                   </FormLabel>
                   <Field
                     component={TextField}
                     fullWidth
-                    label="Password"
+                    label={t('password')}
                     margin="normal"
                     name="password"
                     type="password"
@@ -196,7 +193,7 @@ const RetrieveEntropyView: FC = () => {
                   onClick={submitForm}
                   isSubmitting={isSubmitting}
                 >
-                  Retrieve Entropy
+                  {t('retrieveEntropy')}
                 </SubmitButton>
               </Form>
             );

--- a/app/views/wallet/SettingsView/SettingsOptionsItem.tsx
+++ b/app/views/wallet/SettingsView/SettingsOptionsItem.tsx
@@ -9,6 +9,7 @@ import {
   makeStyles,
   Typography,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 
 import { IconProps } from '../../../components/icons/IconProps';
@@ -40,6 +41,7 @@ const SettingsOptionsItem: FC<SettingsOptionsItemProps> = ({
 }: SettingsOptionsItemProps) => {
   const classes = useStyles();
   const history = useHistory();
+  const { t } = useTranslation('SettingsOptionsItem');
 
   const handleOnClick = () => {
     history.push(path);
@@ -52,7 +54,7 @@ const SettingsOptionsItem: FC<SettingsOptionsItemProps> = ({
           <CardContent>
             <Icon height={34} width={34} />
             <Typography variant="body2" color="textSecondary" component="p">
-              {label}
+              {t(label)}
             </Typography>
           </CardContent>
         </CardActionArea>

--- a/app/views/wallet/SettingsView/index.tsx
+++ b/app/views/wallet/SettingsView/index.tsx
@@ -17,27 +17,27 @@ import SettingsOptionsList from './SettingsOptionsList';
 const settingsOptionsList = [
   {
     Icon: LockIcon,
-    label: 'Change Password',
+    label: 'changePassword',
     path: routePaths.APP_SETTINGS_CHANGE_PASSWORD,
   },
   {
     Icon: KeyIcon,
-    label: 'Retrieve Secret Entropy',
+    label: 'retrieveEntropy',
     path: routePaths.APP_SETTINGS_RETRIEVE_ENTROPY,
   },
   {
     Icon: OfficialDocumentIcon,
-    label: 'Terms of Use',
+    label: 'terms',
     path: routePaths.APP_SETTINGS_TERMS_OF_USE,
   },
   {
     Icon: PrivateDocumentIcon,
-    label: 'Privacy Policy',
+    label: 'privacyPolicy',
     path: routePaths.APP_SETTINGS_PRIVACY_POLICY,
   },
   {
     Icon: ToolsIcon,
-    label: 'Configure MobileCoinD',
+    label: 'configureMobileCoinD',
     path: routePaths.APP_SETTINGS_CONFIGURE_MOBILECOIND,
   },
 ];

--- a/app/views/wallet/TermsOfUseView/index.tsx
+++ b/app/views/wallet/TermsOfUseView/index.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   makeStyles,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { TermsOfUse } from '../../../components';
@@ -70,6 +71,7 @@ const useStyles = makeStyles((theme: Theme) => {
 
 const TermsOfUseView: FC = () => {
   const classes = useStyles();
+  const { t } = useTranslation('TermsOfUseView');
 
   return (
     <Container className={classes.cardContainer} maxWidth="md">
@@ -79,9 +81,9 @@ const TermsOfUseView: FC = () => {
           to={routePaths.APP_SETTINGS}
           component={RouterLink}
         >
-          <Typography color="textSecondary">Settings</Typography>
+          <Typography color="textSecondary">{t('settings')}</Typography>
         </Link>
-        <Typography color="textPrimary">Terms of Use</Typography>
+        <Typography color="textPrimary">{t('terms')}</Typography>
       </Breadcrumbs>
       <Box
         alignItems="center"

--- a/app/views/wallet/TransactionView/SendMobPanel/SendMobForm.tsx
+++ b/app/views/wallet/TransactionView/SendMobPanel/SendMobForm.tsx
@@ -20,6 +20,7 @@ import {
 import { Formik, Form, Field } from 'formik';
 import { RadioGroup, TextField } from 'formik-material-ui';
 import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 
 import { SubmitButton, MOBNumberFormat } from '../../../../components';
@@ -115,6 +116,7 @@ function commafy(num: string) {
 const SendMobForm: FC = () => {
   const classes = useStyles();
   const [confirmation, setConfirmation] = useState(EMPTY_CONFIRMATION);
+  const { t } = useTranslation('SendMobForm');
 
   const [open, setOpen] = useState(false);
   const [isAwaitingConformation, setIsAwaitingConformation] = useState(false);
@@ -150,6 +152,7 @@ const SendMobForm: FC = () => {
   const mockMultipleAccounts: Array<Account> = [
     {
       b58Code: b58Code || '', // TODO -- This hack is to bypass the null state hack on initailization
+      // eslint-disable-next-line max-len
       balance: balance || BigInt(0), // once we move to multiple accounts, we won't have to null the values of an account (better typing!)
       name: accountName,
     },
@@ -164,7 +167,7 @@ const SendMobForm: FC = () => {
           convertMobStringToPicoMobBigInt(values.feeAmount),
           values.recipientPublicAddress,
         );
-        if (result === null || result === undefined) throw new Error('Could not build transaction.');
+        if (result === null || result === undefined) throw new Error(t('error'));
 
         const {
           feeConfirmation,
@@ -195,7 +198,7 @@ const SendMobForm: FC = () => {
   ) => {
     return () => {
       setSlideExitSpeed(0);
-      enqueueSnackbar('Transaction Canceled', {
+      enqueueSnackbar(t('transactionCanceled'), {
         variant: 'warning',
       });
       setOpen(false);
@@ -209,7 +212,7 @@ const SendMobForm: FC = () => {
   const createAccountLabel = (account: Account) => {
     const name = account.name && account.name.length > 0
       ? `${account.name}: `
-      : 'Unnamed Account: ';
+      : `${t('unnamed')}:`;
     return (
       <Box display="flex" justifyContent="space-between">
         <Typography>
@@ -233,12 +236,12 @@ const SendMobForm: FC = () => {
     return (
       <Box pt={2}>
         <FormLabel className={classes.form} component="legend">
-          <Typography color="primary">Select Account</Typography>
+          <Typography color="primary">{t('select')}</Typography>
         </FormLabel>
         <Field component={RadioGroup} name="senderPublicAddress">
           <Box display="flex" justifyContent="space-between">
-            <Typography>Account Name</Typography>
-            <Typography>Account Balance</Typography>
+            <Typography>{t('accountName')}</Typography>
+            <Typography>{t('accountBalance')}</Typography>
           </Box>
           {accounts.map((account: Account) => {
             return (
@@ -264,7 +267,7 @@ const SendMobForm: FC = () => {
       const valueAsPicoMob = BigInt(valueString.replace('.', ''));
       if (valueAsPicoMob + fee > selectedBalance) {
         // TODO - probably want to replace this before launch
-        error = 'Please reserve 0.01 MOB for transaction fee.';
+        error = t('errorFee');
       }
       return error;
     };
@@ -289,10 +292,10 @@ const SendMobForm: FC = () => {
       }}
       validationSchema={Yup.object().shape({
         mobAmount: Yup.number()
-          .positive('A positive, non-zero amount is required to send MOB.')
-          .required('A positive, non-zero amount is required to send MOB.'),
+          .positive(t('positiveValidation'))
+          .required(t('positiveValidationRequired')),
         recipientPublicAddress: Yup.string().required(
-          'A Public Address is required to send MOB.',
+          t('addressRequired'),
         ),
       })}
       validateOnMount
@@ -325,7 +328,7 @@ const SendMobForm: FC = () => {
             );
 
             enqueueSnackbar(
-              `Successfully sent ${totalValueConfirmationAsMobComma} MOB!`,
+              `${t('success')} ${totalValueConfirmationAsMobComma} ${t('mob')}!`,
               {
                 variant: 'success',
               },
@@ -365,6 +368,7 @@ const SendMobForm: FC = () => {
         // NOTE: because this is just a display for the value up to 3 dec mob,
         // We do not need the precision to be BigInt
 
+        // eslint-disable-next-line operator-linebreak
         const selectedBalance =
           // TODO -- this is fine. we'll gut it anyway once we add multiple accounts
           // eslint-disable-next-line
@@ -394,12 +398,12 @@ const SendMobForm: FC = () => {
             )}
             <Box pt={4}>
               <FormLabel component="legend">
-                <Typography color="primary">Transaction Details</Typography>
+                <Typography color="primary">{t('transaction')}</Typography>
               </FormLabel>
               <Field
                 component={TextField}
                 fullWidth
-                label="Recipient Public Address"
+                label={t('recipient')}
                 margin="normal"
                 name="recipientPublicAddress"
                 type="text"
@@ -407,7 +411,7 @@ const SendMobForm: FC = () => {
               <Field
                 component={TextField}
                 fullWidth
-                label="MOB Amount"
+                label={t('mobAmount')}
                 margin="normal"
                 name="mobAmount"
                 id="mobAmount"
@@ -435,7 +439,7 @@ const SendMobForm: FC = () => {
             {!isSynced && (
               <Box mt={3}>
                 <FormHelperText error>
-                  Wallet must sync with ledger before sending MOB.
+                  {t('mustSync')}
                 </FormHelperText>
               </Box>
             )}
@@ -444,7 +448,7 @@ const SendMobForm: FC = () => {
               onClick={handleOpen(values, setStatus, setErrors)}
               isSubmitting={isAwaitingConformation || isSubmitting}
             >
-              {isSynced ? 'Send Payment' : 'Wallet syncing...'}
+              {isSynced ? t('send') : t('syncing')}
             </SubmitButton>
             {/* TODO - disable model if invalid */}
             <Modal
@@ -463,14 +467,18 @@ const SendMobForm: FC = () => {
             >
               <Slide in={open} timeout={{ enter: 0, exit: slideExitSpeed }}>
                 <div className={classes.paper}>
-                  <h2 id="transition-modal-title">Send MOB Confirmation</h2>
+                  <h2 id="transition-modal-title">{t('confirm')}</h2>
                   <p id="transition-modal-description">
-                    Please check and confirm your payment intent:
+                    {t('intent')}
+                    :
                   </p>
                   <br />
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Account Balance:</Typography>
+                    <Typography>
+                      {t('accountBalance')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -485,7 +493,10 @@ const SendMobForm: FC = () => {
                   </Box>
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography color="primary">Amount:</Typography>
+                    <Typography color="primary">
+                      {t('amount')}
+                      :
+                    </Typography>
                     <Typography color="primary">
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -496,7 +507,10 @@ const SendMobForm: FC = () => {
                   </Box>
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Fee:</Typography>
+                    <Typography>
+                      {t('fee')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -507,7 +521,10 @@ const SendMobForm: FC = () => {
                   </Box>
 
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Total:</Typography>
+                    <Typography>
+                      {t('total')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -521,7 +538,10 @@ const SendMobForm: FC = () => {
                     <Typography>---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>Remaining Balance:</Typography>
+                    <Typography>
+                      {t('remaining')}
+                      :
+                    </Typography>
                     <Typography>
                       <MOBNumberFormat
                         suffix=" MOB"
@@ -533,7 +553,7 @@ const SendMobForm: FC = () => {
                   <br />
 
                   <p className={classes.center}>
-                    Recipient Address (Their Address)
+                    {t('recipientPlus')}
                   </p>
                   <LongCode
                     code={confirmation?.txProposalReceiverB58Code}
@@ -543,7 +563,7 @@ const SendMobForm: FC = () => {
                   <br />
 
                   <p className={classes.center}>
-                    Sender Address (Your Address)
+                    {t('senderPlus')}
                   </p>
                   <LongCode
                     code={values.senderPublicAddress}
@@ -562,7 +582,7 @@ const SendMobForm: FC = () => {
                       type="submit"
                       variant="contained"
                     >
-                      Cancel
+                      {t('cancel')}
                     </Button>
                     <Button
                       className={classes.button}
@@ -574,7 +594,7 @@ const SendMobForm: FC = () => {
                       type="submit"
                       variant="contained"
                     >
-                      Confirm Send
+                      {t('confirmSend')}
                     </Button>
                   </Box>
                 </div>

--- a/app/views/wallet/TransactionView/SendMobPanel/index.tsx
+++ b/app/views/wallet/TransactionView/SendMobPanel/index.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react';
 import {
   Box, Container, Typography, makeStyles,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import SendMobForm from './SendMobForm';
 
@@ -19,6 +20,7 @@ const useStyles = makeStyles(() => {
 // TODO -- we need PENDING STATUS for payments in MobileCoinD
 const SendMobPanel: FC = () => {
   const classes = useStyles();
+  const { t } = useTranslation('SendMobPanel');
 
   return (
     <Container className={classes.cardContainer} maxWidth="sm">
@@ -30,8 +32,7 @@ const SendMobPanel: FC = () => {
       >
         <Box>
           <Typography variant="body2" color="textSecondary">
-            Please enter the amount of MOB you want to send and the public
-            address of the recipient.
+            {t('header')}
           </Typography>
         </Box>
       </Box>

--- a/app/views/wallet/TransactionView/index.tsx
+++ b/app/views/wallet/TransactionView/index.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react';
 import {
   Box, Grid, makeStyles, Tab, Tabs,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import TabPanel from '../../../components/TabPanel';
 import type { Theme } from '../../../theme';
@@ -23,6 +24,7 @@ const useStyles = makeStyles((theme: Theme) => {
 const TransactionView: FC = () => {
   const classes = useStyles();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const { t } = useTranslation('TransactionView');
 
   const handleChange = (
     _event: React.ChangeEvent<Record<string, unknown>>,
@@ -42,8 +44,8 @@ const TransactionView: FC = () => {
             textColor="secondary"
             onChange={handleChange}
           >
-            <Tab label="Send MOB" />
-            <Tab label="Receive MOB" />
+            <Tab label={t('send')} />
+            <Tab label={t('receive')} />
           </Tabs>
           <TabPanel
             panels={[SendMobPanel, ReceiveMobPanel]}

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -257,5 +257,18 @@
   "PrivacyPolicyView": {
     "settings": "Settings",
     "privacyPolicy": "Privacy Policy"
+  },
+
+  "RetrieveEntropyView": {
+    "settings": "Settings",
+    "retrieveSecret": "Retrieve Secret Entropy",
+    "header": "Your Entropy is the",
+    "description": "that unlocks your wallet and allows you to use MobileCoin. It is unique to your account. It is important that you never share this code. You may wish to use this code in a secure, safe manner. This wallet uses your password to store an encrypted Entropy.",
+    "entropyCanBeUsed": "The Entropy can be used to import your wallet in case your device is damaged or lost. It allows you to add your account to other wallets.",
+    "misplacedYourEntropy": "If you have forgotten or misplaced your Entropy, you may retrieve here with your password.",
+    "passwordRequired": "Password is required",
+    "error": "Hmm, something went wrong.",
+    "retrieveEntropy": "Retrieve Entropy",
+    "password": "Password"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -270,5 +270,13 @@
     "error": "Hmm, something went wrong.",
     "retrieveEntropy": "Retrieve Entropy",
     "password": "Password"
+  },
+
+  "ShowRetrievedEntropyModal": {
+    "header": "This is your secret Entropy!",
+    "description": "We decrypted your Entropy and will now show you the code on your screen. Please store this code in a secure, private manner. You will need your Entropy to import this account into other wallets.",
+    "hide": "Hide Secret Entropy",
+    "show": "Show Secret Entropy",
+    "secured": "I have secured my Entropy"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -252,5 +252,10 @@
     "newBalance": "New Balance",
     "cancel": "Cancel",
     "claimGift": "Claim Gift"
+  },
+
+  "PrivacyPolicyView": {
+    "settings": "Settings",
+    "privacyPolicy": "Privacy Policy"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -278,5 +278,13 @@
     "hide": "Hide Secret Entropy",
     "show": "Show Secret Entropy",
     "secured": "I have secured my Entropy"
+  },
+
+  "SettingsOptionsItem": {
+    "changePassword": "Change Password",
+    "retrieveEntropy": "Retrieve Secret Entropy",
+    "terms": "Terms of Use",
+    "privacyPolicy": "Privacy Policy",
+    "configureMobileCoinD": "Configure MobileCoinD"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -300,5 +300,36 @@
 
   "SendMobPanel": {
     "header": "Please enter the amount of MOB you want to send and the public address of the recipient."
+  },
+
+  "SendMobForm": {
+    "error": "Could not build transaction.",
+    "transactionCanceled": "Transaction Canceled",
+    "unnamed": "Unnamed Account",
+    "select": "Select Account",
+    "accountName": "Account Name",
+    "accountBalance": "Account Balance",
+    "errorFee": "Please reserve 0.01 MOB for transaction fee.",
+    "positiveValidation": "A positive, non-zero amount is required to send MOB.",
+    "positiveValidationRequired": "A positive, non-zero amount is required to send MOB.",
+    "addressRequired": "A Public Address is required to send MOB.",
+    "success": "Successfully sent ",
+    "mob": "MOB",
+    "transaction": "Transaction Details",
+    "recipient": "Recipient Public Address",
+    "mobAmount": "MOB Amount",
+    "mustSync": "Wallet must sync with ledger before sending MOB.",
+    "send": "Send Payment",
+    "syncing": "Wallet syncing...",
+    "confirm": "Send MOB Confirmation",
+    "intent": "Please check and confirm your payment intent",
+    "amount": "Amount",
+    "fee": "Fee",
+    "total": "Total",
+    "remaining": "Remaining Balance",
+    "recipientPlus": "Recipient Address (Their Address)",
+    "senderPlus": "Sender Address (Your Address)",
+    "cancel": "Cancel",
+    "confirmSend": "Confirm Send"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -291,5 +291,10 @@
   "TermsOfUseView": {
     "settings": "Settings",
     "terms": "Terms of Use"
+  },
+
+  "TransactionView": {
+    "send": "Send MOB",
+    "receive": "Receive MOB"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -296,5 +296,9 @@
   "TransactionView": {
     "send": "Send MOB",
     "receive": "Receive MOB"
+  },
+
+  "SendMobPanel": {
+    "header": "Please enter the amount of MOB you want to send and the public address of the recipient."
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -286,5 +286,10 @@
     "terms": "Terms of Use",
     "privacyPolicy": "Privacy Policy",
     "configureMobileCoinD": "Configure MobileCoinD"
+  },
+
+  "TermsOfUseView": {
+    "settings": "Settings",
+    "terms": "Terms of Use"
   }
 }

--- a/test/components/SplashScreen/__snapshots__/SplashScreen.test.tsx.snap
+++ b/test/components/SplashScreen/__snapshots__/SplashScreen.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`SplashScreen renders to screen when called 1`] = `
 <DocumentFragment>
   <div
     class="MuiBox-root MuiBox-root makeStyles-root"
-    data-testid="splash-screen"
   >
     <div
       class="MuiBox-root MuiBox-root"


### PR DESCRIPTION
Soundtrack of this PR: [Nba Youngboy- It Ain’t Over (Interlude)](https://www.youtube.com/watch?v=MpdWc0LAQVo)

### Motivation :globe_with_meridians:

Prepping app for globalization by replacing copy with keys instead of strings. `enUS` doc will house all of the apps default copy for ease of translation implementations.

### In this PR
Wrap up of remaining views directories being added to `enUS`:
- PrivacyPolicyView
- RetrieveEntropyView
- SettingsView
- TermsOfUseView
- TransactionView

### Future Work
Add remaining one-off components and layouts with user facing text 