### PR TITLE
Adding final copy to enUS

### DIFF
--- a/app/components/TermsOfUseDialog.tsx
+++ b/app/components/TermsOfUseDialog.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   Box, Button, Container, Dialog,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import TermsOfUse from './TermsOfUse';
 
@@ -13,6 +14,7 @@ interface TermsOfUseDialogProps {
 
 const TermsOfUseDialog = (props: TermsOfUseDialogProps): JSX.Element => {
   const { open, handleCloseTerms } = props;
+  const { t } = useTranslation('TermsOfUseDialog');
 
   return (
     <Dialog fullScreen open={open} disableEscapeKeyDown disableBackdropClick>
@@ -25,7 +27,7 @@ const TermsOfUseDialog = (props: TermsOfUseDialogProps): JSX.Element => {
             variant="contained"
             fullWidth
           >
-            Close Terms of Use
+            {t('close')}
           </Button>
         </Box>
         <Box p={2} />

--- a/app/layouts/DashboardLayout/ShowEntropyModal.tsx
+++ b/app/layouts/DashboardLayout/ShowEntropyModal.tsx
@@ -13,6 +13,7 @@ import {
   Modal,
   Typography,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import useMobileCoinD from '../../hooks/useMobileCoinD';
 import type { Theme } from '../../theme';
@@ -46,6 +47,7 @@ const ShowEntropyModal: FC = () => {
   const [canGoForward, setCanGoForward] = useState(false);
   const [showEntropy, setShowEntropy] = useState(false);
   const { entropy, isEntropyKnown, confirmEntropyKnown } = useMobileCoinD();
+  const { t } = useTranslation('ShowEntropyModal');
   const handleCloseModal = () => {
     confirmEntropyKnown();
   };
@@ -91,13 +93,11 @@ const ShowEntropyModal: FC = () => {
         {!alertOpen ? (
           <Box className={classes.paper} display="flex" flexDirection="column">
             <Typography color="textPrimary" gutterBottom variant="h2">
-              Welcome to the MobileCoin Desktop Wallet!
+              {t('header')}
             </Typography>
             <br />
             <Typography variant="body2" color="textSecondary">
-              We generated a random Entropy to create your new account. Please
-              store this code in a secure, private manner. You will need your
-              Entropy to import this account into other wallets.
+              {t('description')}
             </Typography>
             <br />
 
@@ -117,8 +117,8 @@ const ShowEntropyModal: FC = () => {
                       size="small"
                     >
                       {showEntropy
-                        ? 'Hide Secret Entropy'
-                        : 'Show Secret Entropy'}
+                        ? t('hide')
+                        : t('show')}
                     </Fab>
                   </Box>
                   {showEntropy ? (
@@ -151,23 +151,21 @@ const ShowEntropyModal: FC = () => {
               type="submit"
               variant="contained"
             >
-              I have secured my Entropy
+              {t('secured')}
             </Button>
           </Box>
         ) : (
           <Box className={classes.paper}>
             <Typography color="textPrimary" gutterBottom variant="h2">
-              Confirm you have secured Entropy
+              {t('confirm')}
             </Typography>
             <br />
             <Typography variant="body2" color="textSecondary">
-              If you need to see your entropy again, you may retrieve it from
-              the Settings tab with your password. However, if you forget your
-              password or lose this device, you will need to know your Entropy.
+              {t('retrieve')}
             </Typography>
             <br />
             <Typography variant="body2" color="textSecondary">
-              We recommend storing your entropy in a secure manner.
+              {t('recommend')}
             </Typography>
             <br />
 
@@ -180,7 +178,7 @@ const ShowEntropyModal: FC = () => {
                 type="submit"
                 variant="contained"
               >
-                Go back...
+                {t('back')}
               </Button>
               <Box paddingX={2} />
               <Button
@@ -191,7 +189,7 @@ const ShowEntropyModal: FC = () => {
                 type="submit"
                 variant="contained"
               >
-                Yes, I have secured my Entropy
+                {t('yes')}
               </Button>
             </Box>
           </Box>

--- a/app/layouts/DashboardLayout/TopBar/NavBar.tsx
+++ b/app/layouts/DashboardLayout/TopBar/NavBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { FC } from 'react';
 
 import { Tab, Tabs } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 import {
   NavLink as RouterLink,
   matchPath,
@@ -31,28 +32,29 @@ interface Section {
 const sections: Section[] = [
   {
     Icon: WalletHomeIcon,
-    label: 'Home',
+    label: 'home',
     path: routePaths.APP_DASHBOARD,
   },
   {
     Icon: TransactionIcon,
-    label: 'Send/Receive',
+    label: 'transaction',
     path: routePaths.APP_TRANSACTION,
   },
   {
     Icon: GiftIcon,
-    label: 'Gifting',
+    label: 'gift',
     path: routePaths.APP_GIFTING,
   },
   {
     Icon: CogIcon,
-    label: 'Settings',
+    label: 'settings',
     path: routePaths.APP_SETTINGS,
   },
 ];
 
 const NavBar: FC<NavBarProps> = () => {
   const location = useLocation();
+  const { t } = useTranslation('NavBar');
   const value = sections.findIndex((section) => {
     return matchPath(location.pathname, {
       exact: false,
@@ -71,7 +73,7 @@ const NavBar: FC<NavBarProps> = () => {
             component={RouterLink}
             to={path}
             icon={<Icon height={32} width={32} color={color} />}
-            label={label}
+            label={t(label)}
             key={label}
           />
         );

--- a/app/layouts/DashboardLayout/TopBar/SyncStatus.tsx
+++ b/app/layouts/DashboardLayout/TopBar/SyncStatus.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react';
 import {
   Box, makeStyles, Tooltip, CircularProgress,
 } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
 
 import { CircleMOBIcon } from '../../../components/icons';
 import { GREEN, GOLD_LIGHT, RED } from '../../../constants/colors';
@@ -49,6 +50,7 @@ const useStyles = makeStyles(() => {
 const SyncStatus: FC = () => {
   const classes = useStyles();
   const { networkHighestBlockIndex, nextBlock } = useMobileCoinD();
+  const { t } = useTranslation('SyncStatus');
 
   let percentSynced;
   let isSynced;
@@ -78,17 +80,17 @@ const SyncStatus: FC = () => {
   switch (statusCode) {
     case SYNCED: {
       backgroundColor = GREEN;
-      title = '100%: synced with the ledger';
+      title = t('synced');
       break;
     }
     case SYNCING: {
       backgroundColor = GOLD_LIGHT;
-      title = `${percentSynced}%: Syncing with the ledger`;
+      title = `${percentSynced}%: ${t('syncing')}`;
       break;
     }
     default: {
       backgroundColor = RED;
-      title = 'Please see Admin Panel in Settings.';
+      title = t('error');
     }
   }
 

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -342,5 +342,11 @@
     "transaction": "Send/Receive",
     "gift": "Gifting",
     "settings": "Settings"
+  },
+
+  "SyncStatus": {
+    "synced": "100%: synced with the ledger",
+    "syncing": "Syncing with the ledger",
+    "error": "Please see Admin Panel in Settings."
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -335,5 +335,12 @@
 
   "TermsOfUseDialog": {
     "close": "Close Terms of Use"
+  },
+
+  "NavBar": {
+    "home": "Home",
+    "transaction": "Send/Receive",
+    "gift": "Gifting",
+    "settings": "Settings"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -331,5 +331,9 @@
     "senderPlus": "Sender Address (Your Address)",
     "cancel": "Cancel",
     "confirmSend": "Confirm Send"
+  },
+
+  "TermsOfUseDialog": {
+    "close": "Close Terms of Use"
   }
 }

--- a/locales/enUS.json
+++ b/locales/enUS.json
@@ -348,5 +348,18 @@
     "synced": "100%: synced with the ledger",
     "syncing": "Syncing with the ledger",
     "error": "Please see Admin Panel in Settings."
+  },
+
+  "ShowEntropyModal": {
+    "header": "Welcome to the MobileCoin Desktop Wallet!",
+    "description": "We generated a random Entropy to create your new account. Please store this code in a secure, private manner. You will need your Entropy to import this account into other wallets.",
+    "hide": "Hide Secret Entropy",
+    "show": "Show Secret Entropy",
+    "secured": "I have secured my Entropy",
+    "confirm": "Confirm you have secured Entropy",
+    "retrieve": "If you need to see your entropy again, you may retrieve it from the Settings tab with your password. However, if you forget your password or lose this device, you will need to know your Entropy.",
+    "recommend": "We recommend storing your entropy in a secure manner.",
+    "back": "Go back...",
+    "yes": "Yes, I have secured my Entropy"
   }
 }


### PR DESCRIPTION
Soundtrack of this PR: [OutKast - In Due Time (Official Video)](https://www.youtube.com/watch?v=gvMCA9jHFZ0)

### Motivation :globe_with_meridians:

Prepping app for globalization by replacing copy with keys instead of strings. `enUS` doc will house all of the apps default copy for ease of translation implementations.

### In this PR
Last round up of copy being added to `enUS`:
- TermsOfUseDialog
- NavBar
- SyncStatus
- ShowEntropyModal