### PR TITLE
Test WalletGuard

### DIFF
--- a/test/components/UnlockWalletGuard/UnlockWalletGuard.test.tsx
+++ b/test/components/UnlockWalletGuard/UnlockWalletGuard.test.tsx
@@ -8,7 +8,7 @@ import renderSnapshot from '../../renderSnapshot';
 
 jest.mock('../../../app/hooks/useMobileCoinD');
 
-function setupComponent(contextOverides?: MobileCoinDContextValue) {
+function setupComponent(contextOverrides?: MobileCoinDContextValue) {
   const defaultContext = {
     encryptedEntropy: null,
     isAuthenticated: false,
@@ -18,7 +18,7 @@ function setupComponent(contextOverides?: MobileCoinDContextValue) {
     <UnlockWalletGuard>children</UnlockWalletGuard>,
     {
       ...defaultContext,
-      ...contextOverides,
+      ...contextOverrides,
     },
   );
 

--- a/test/components/WalletGuard/WalletGuard.test.tsx
+++ b/test/components/WalletGuard/WalletGuard.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { WalletGuard } from '../../../app/components';
+import { MobileCoinDContextValue } from '../../../app/contexts/MobileCoinDContext';
+import renderSnapshot from '../../renderSnapshot';
+
+jest.mock('../../../app/hooks/useMobileCoinD');
+
+function setupComponent(contextOverides?: MobileCoinDContextValue) {
+  const defaultContext = {
+    encryptedEntropy: null,
+    isAuthenticated: false,
+  };
+
+  renderSnapshot(
+    <WalletGuard>success</WalletGuard>,
+    {
+      ...defaultContext,
+      ...contextOverides,
+    },
+  );
+
+  const success = screen.queryByText('success');
+
+  return {
+    success,
+  };
+}
+
+describe('WalletGuard', () => {
+  test('authenticated users with entropy are given access to children prop of WalletGuard', () => {
+    // @ts-ignore mock
+    const { success } = setupComponent({
+      encryptedEntropy: 'string',
+      isAuthenticated: true,
+    });
+    expect(success).toBeInTheDocument();
+  });
+
+  test('unauthenticated users with no entropy are redirected to CreateAccountView', () => {
+    const { success } = setupComponent();
+    expect(success).not.toBeInTheDocument();
+    expect(screen.queryByTestId('CreateAccountView')).toBeInTheDocument();
+  });
+
+  test('unauthenticated users with entropy are redirected to UnlockWalletView ', () => {
+    // @ts-ignore mock
+    setupComponent({
+      encryptedEntropy: 'string',
+      isAuthenticated: false,
+    });
+    expect(screen.queryByTestId('UnlockWalletView')).toBeInTheDocument();
+  });
+
+  test('authenticated users with no entropy are given access to children prop of WalletGuard', () => {
+    // @ts-ignore mock
+    const { success } = setupComponent({
+      isAuthenticated: true,
+    });
+    expect(success).toBeInTheDocument();
+  });
+});

--- a/test/components/WalletGuard/WalletGuard.test.tsx
+++ b/test/components/WalletGuard/WalletGuard.test.tsx
@@ -8,7 +8,7 @@ import renderSnapshot from '../../renderSnapshot';
 
 jest.mock('../../../app/hooks/useMobileCoinD');
 
-function setupComponent(contextOverides?: MobileCoinDContextValue) {
+function setupComponent(contextOverrides?: MobileCoinDContextValue) {
   const defaultContext = {
     encryptedEntropy: null,
     isAuthenticated: false,
@@ -18,7 +18,7 @@ function setupComponent(contextOverides?: MobileCoinDContextValue) {
     <WalletGuard>success</WalletGuard>,
     {
       ...defaultContext,
-      ...contextOverides,
+      ...contextOverrides,
     },
   );
 

--- a/test/renderSnapshot.tsx
+++ b/test/renderSnapshot.tsx
@@ -30,7 +30,7 @@ const generateClassName: StylesOptions['generateClassName'] = (
 // We should consider setting up the testing environment in an easier, unified way.
 const renderSnapshot = (
   testComponent: ReactElement,
-  mobilecoindContextOverides?: MobileCoinDContextValue,
+  mobilecoindContextOverrides?: MobileCoinDContextValue,
 ) => {
   const theme = setTheme({
     responsiveFontSizes: true,
@@ -64,7 +64,7 @@ const renderSnapshot = (
     nextBlock: '1235',
     receiver: null,
     ...mockUseMobileCoinDFunctions,
-    ...mobilecoindContextOverides,
+    ...mobilecoindContextOverrides,
   };
 
   // @ts-ignore mock

--- a/test/views/auth/CreateAccountView/CreateAccountView.test.tsx
+++ b/test/views/auth/CreateAccountView/CreateAccountView.test.tsx
@@ -9,7 +9,7 @@ import renderSnapshot from '../../../renderSnapshot';
 
 jest.mock('../../../../app/hooks/useMobileCoinD');
 
-function setupComponent(contextOverides?: MobileCoinDContextValue) {
+function setupComponent(contextOverrides?: MobileCoinDContextValue) {
   // Default Context
   const defaultContext = {
     encryptedEntropy: 'existing encrypted entropy',
@@ -20,7 +20,7 @@ function setupComponent(contextOverides?: MobileCoinDContextValue) {
     <CreateAccountView isTest />,
     {
       ...defaultContext,
-      ...contextOverides,
+      ...contextOverrides,
     },
   );
 

--- a/test/views/auth/ImportAccountView/ImportAccountView.test.tsx
+++ b/test/views/auth/ImportAccountView/ImportAccountView.test.tsx
@@ -9,7 +9,7 @@ import renderSnapshot from '../../../renderSnapshot';
 
 jest.mock('../../../../app/hooks/useMobileCoinD');
 
-function setupComponent(contextOverides?: MobileCoinDContextValue) {
+function setupComponent(contextOverrides?: MobileCoinDContextValue) {
   // Default Context
   const defaultContext = {
     encryptedEntropy: 'existing encrypted entropy',
@@ -20,7 +20,7 @@ function setupComponent(contextOverides?: MobileCoinDContextValue) {
     <ImportAccountView isTest />,
     {
       ...defaultContext,
-      ...contextOverides,
+      ...contextOverrides,
     },
   );
 


### PR DESCRIPTION
Soundtrack of this PR: [Unlock The Swag · Rae Sremmurd · Jace of Two-9](https://www.youtube.com/watch?v=0rNKdCNSmbc)

### Motivation :lock:

Continued test coverage expansion for Desktop Wallet components, views, utils and hooks.

### In this PR

- Testing view renders for authenticated and unauthenticated users
- Testing appropriate child prop renders for authenticated and unauthenticated users
- Updated tests to check for auth scenarios with and without entropy. 

### Caveats

- Currently authenticated users without entropy are given access to `DashboardView` without a redirect. Spike worthy???

### Testing
 PASS  test/components/WalletGuard/WalletGuard.test.tsx (37.389 s)
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------|---------|----------|---------|---------|-------------------
WalletGuard.tsx                              |     100 |      100 |     100 |     100 |       

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        45.069 s