### PR TITLE
Change mobileocoin.com to mobilecoin.com

### DIFF
--- a/app/contexts/MobileCoinDContext.tsx
+++ b/app/contexts/MobileCoinDContext.tsx
@@ -278,7 +278,7 @@ const reducer = (state: MobileCoinDState, action: Action): MobileCoinDState => {
         balance,
         isAuthenticated: true,
         isEntropyKnown: true,
-        mobUrl: `https://mobileocoin.com/mob58/${b58Code}`,
+        mobUrl: `https://mobilecoin.com/mob58/${b58Code}`,
         monitorId,
         receiver,
       };
@@ -300,7 +300,7 @@ const reducer = (state: MobileCoinDState, action: Action): MobileCoinDState => {
         entropy,
         isAuthenticated: true,
         isEntropyKnown: false,
-        mobUrl: `https://mobileocoin.com/mob58/${b58Code}`,
+        mobUrl: `https://mobilecoin.com/mob58/${b58Code}`,
         monitorId,
         receiver,
       };
@@ -348,7 +348,7 @@ const reducer = (state: MobileCoinDState, action: Action): MobileCoinDState => {
         balance,
         isAuthenticated: true,
         isEntropyKnown: true,
-        mobUrl: `https://mobileocoin.com/mob58/${b58Code}`,
+        mobUrl: `https://mobilecoin.com/mob58/${b58Code}`,
         monitorId,
         receiver,
       };

--- a/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
+++ b/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
@@ -526,7 +526,7 @@ const BuildGiftForm: FC = () => {
                       isGift
                       account={{
                         b58Code: confirmation?.giftB58Code,
-                        mobUrl: `https://mobileocoin.com/mob58/${confirmation?.giftB58Code}`,
+                        mobUrl: `https://mobilecoin.com/mob58/${confirmation?.giftB58Code}`,
                         name: t('pending'),
                       }}
                     />

--- a/app/views/wallet/GiftingView/BuildGiftPanel/index.tsx
+++ b/app/views/wallet/GiftingView/BuildGiftPanel/index.tsx
@@ -214,7 +214,7 @@ const BuildGiftPanel: FC = () => {
                 isGift
                 account={{
                   b58Code: pendingDeleteCode[0],
-                  mobUrl: `https://mobileocoin.com/mob58/${pendingDeleteCode[0]}`,
+                  mobUrl: `https://mobilecoin.com/mob58/${pendingDeleteCode[0]}`,
                   name: 'Gift Code',
                 }}
               />


### PR DESCRIPTION
Soundtrack of this PR: [Classic Sesame Street - Word Family "OP" (Muppets)](https://www.youtube.com/watch?v=KWZbWzF7YN4)

### Motivation

Our website is mobilecoin.com not mobileocoin.com. This is something I would do (deep sigh).

### In this PR

- Correctly spell our name.

### Caveats

- I now am the owner of mobileocoin.com to prevent an advantageous phishing exploit (continued deep sigh).
