### PR TITLE
Add encrypted entropy to auth actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     # Reuse Docker container specification given by the node Orb
     executor: node/default
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - node/install:
@@ -25,9 +25,9 @@ jobs:
   test:
     docker:
       - image: circleci/node:latest-browsers
-    resource_class: large
+    resource_class: xlarge
     environment:
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=8192
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
   build:
     # Reuse Docker container specification given by the node Orb
     executor: node/default
+    resource_class: large
     steps:
       - checkout
       - node/install:
@@ -25,6 +26,8 @@ jobs:
     docker:
       - image: circleci/node:latest-browsers
     resource_class: large
+    environment:
+      NODE_OPTIONS: --max-old-space-size=4096
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:

--- a/app/contexts/MobileCoinDContext.tsx
+++ b/app/contexts/MobileCoinDContext.tsx
@@ -846,9 +846,10 @@ export const MobileCoinDProvider: FC<MobileCoinDProviderProps> = ({
     };
   }, [state, client]);
 
-  // if (!state.isInitialised) {
-  //   return <SplashScreen />;
-  // }
+  if (!state.isInitialised) {
+    return <SplashScreen />;
+  }
+
   return (
     <MobileCoinDContext.Provider
       value={{

--- a/app/contexts/MobileCoinDContext.tsx
+++ b/app/contexts/MobileCoinDContext.tsx
@@ -146,6 +146,7 @@ type ImportAccountAction = {
     accountName: string | null;
     b58Code: string;
     balance: bigint;
+    encryptedEntropy: string;
     monitorId: Buffer;
     receiver: PublicAddress;
   };
@@ -268,6 +269,7 @@ const reducer = (state: MobileCoinDState, action: Action): MobileCoinDState => {
         accountName,
         b58Code,
         balance,
+        encryptedEntropy,
         monitorId,
         receiver,
       } = action.payload;
@@ -276,6 +278,7 @@ const reducer = (state: MobileCoinDState, action: Action): MobileCoinDState => {
         accountName,
         b58Code,
         balance,
+        encryptedEntropy,
         isAuthenticated: true,
         isEntropyKnown: true,
         mobUrl: `https://mobileocoin.com/mob58/${b58Code}`,

--- a/app/contexts/MobileCoinDContext.tsx
+++ b/app/contexts/MobileCoinDContext.tsx
@@ -846,9 +846,9 @@ export const MobileCoinDProvider: FC<MobileCoinDProviderProps> = ({
     };
   }, [state, client]);
 
-  if (!state.isInitialised) {
-    return <SplashScreen />;
-  }
+  // if (!state.isInitialised) {
+  //   return <SplashScreen />;
+  // }
   return (
     <MobileCoinDContext.Provider
       value={{

--- a/app/contexts/MobileCoinDContext.tsx
+++ b/app/contexts/MobileCoinDContext.tsx
@@ -134,6 +134,7 @@ type GenerateEntropyAction = {
     accountName: string | null;
     b58Code: string;
     balance: bigint;
+    encryptedEntropy: string;
     entropy: Buffer;
     monitorId: Buffer;
     receiver: PublicAddress;
@@ -291,6 +292,7 @@ const reducer = (state: MobileCoinDState, action: Action): MobileCoinDState => {
         accountName,
         b58Code,
         balance,
+        encryptedEntropy,
         entropy,
         monitorId,
         receiver,
@@ -300,6 +302,7 @@ const reducer = (state: MobileCoinDState, action: Action): MobileCoinDState => {
         accountName,
         b58Code,
         balance,
+        encryptedEntropy,
         entropy,
         isAuthenticated: true,
         isEntropyKnown: false,

--- a/app/contexts/MobileCoinDContext.tsx
+++ b/app/contexts/MobileCoinDContext.tsx
@@ -128,7 +128,7 @@ type FetchBalanceAction = {
   };
 };
 
-type GenerateEntropyAction = {
+type CreateAccountAction = {
   type: 'CREATE_ACCOUNT';
   payload: {
     accountName: string | null;
@@ -195,7 +195,7 @@ type Action =
   | UpdateGiftCodesAction
   | ConfirmEntropyKnownAction
   | FetchBalanceAction
-  | GenerateEntropyAction
+  | CreateAccountAction
   | ImportAccountAction
   | InitialiseAction
   | PayAddressCodeAction

--- a/app/mobilecoind/services/EncryptEntropyService.ts
+++ b/app/mobilecoind/services/EncryptEntropyService.ts
@@ -56,7 +56,7 @@ class EncryptEntropyService extends BaseService<EncryptEntropyServiceArgs> {
       LocalStoreInstance.setSalt(publicSaltString);
       LocalStoreInstance.setName(name);
 
-      return this.handleSuccess({});
+      return this.handleSuccess({ encryptedEntropy });
     } catch (err) {
       return this.handleError(err);
     }

--- a/app/mobilecoind/services/ImportAccountService.ts
+++ b/app/mobilecoind/services/ImportAccountService.ts
@@ -70,6 +70,7 @@ class ImportAccountService extends BaseService<ImportAccountServiceArgs> {
           password,
         });
         const {
+          data: encryptedEntropy,
           isSuccess,
           errorMessage,
         } = await EncryptEntropyServiceInstance.call();
@@ -79,6 +80,7 @@ class ImportAccountService extends BaseService<ImportAccountServiceArgs> {
             accountName: name, // this is hacking using the input. something is wrong with mob d
             b58Code,
             balance,
+            encryptedEntropy,
             entropy,
             monitorId,
             receiver,


### PR DESCRIPTION
Soundtrack of this PR: [MobileCoin Radio #001 Full Show](https://www.youtube.com/watch?v=wteZAejKbFk)

### Motivation

We introduced a very specific bug that occurred for the first time an entropy is encrypted.

### In this PR

- Return encryptedEntropy in EncryptEntropyService
- Return encryptedEntropy in ImportAccountService
- Add encryptedEntropy to ImportAccountAction payload
- Add encryptedEntropy to GenerateEntropyAction payload
- Rename GenerateEntropyAction to CreateAccountAction

### Testing
I am currently nuking these files (mobilecoind) in favor to the Full-Service api. This PR was just to acknowledge the bug if anyone is building the wallet themselves.
