### PR TITLE
Added justify-content: space-between

### DIFF
--- a/app/app.global.css
+++ b/app/app.global.css
@@ -13,3 +13,7 @@ body {
   overflow-y: hidden;
   letter-spacing: 4px;
 }
+
+.MuiTabs-flexContainer {
+  justify-content: space-between;
+}


### PR DESCRIPTION
This will space the items to fill the width when there is enough space to fill them all, so that the MobileCoin icon doesn't cover any tab icon (as long as there is an even number of tabs)

Soundtrack of this PR: [Am I Pretty?](https://www.youtube.com/watch?v=zKu0ItDzJH8)

### Motivation

I felt at least showing this would be worth the time investment (almost no time, 3 lines of code) to see if it was something to consider changing.

### In this PR

Added justify-content: space-between to tab items when stretched beyond reactive width scrolling size limit

### Caveats

None

### Future Work

None

### Screen Shots
<img width="832" alt="Screen Shot 2021-03-02 at 4 16 30 PM" src="https://user-images.githubusercontent.com/4346395/109716350-c5cd8200-7b72-11eb-8a9a-b3bea9097256.png">
<img width="1792" alt="Screen Shot 2021-03-02 at 4 16 11 PM" src="https://user-images.githubusercontent.com/4346395/109716351-c6661880-7b72-11eb-8c86-e96ab7ed35f0.png">
<img width="1792" alt="Screen Shot 2021-03-02 at 4 15 55 PM" src="https://user-images.githubusercontent.com/4346395/109716352-c6feaf00-7b72-11eb-8b36-b0b2632a2bd5.png">

| Screen Name                                             | Before | After |
| :------------------------------------------------------ | :----: | :---: |
| <please always include, at least, a min and max screen> |        |       |

### Testing

Test Suites: 25 passed, 25 total
Tests:       108 passed, 108 total
Snapshots:   8 passed, 8 total
Time:        42.817 s
Ran all test suites.
✨  Done in 44.88s.