### PR TITLE
Inherit to Const color code

### DIFF
--- a/app/components/LongCode.tsx
+++ b/app/components/LongCode.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 
 import { Box, makeStyles } from '@material-ui/core';
 
-import { GOLD_DARK, GOLD_LIGHT } from '../constants/colors';
+import { GOLD_DARK, GOLD_LIGHT, WHITE } from '../constants/colors';
 
 interface LongCodeProps {
   code: string;
@@ -24,7 +24,7 @@ const LongCode: FC<LongCodeProps> = ({ code, codeClass }: LongCodeProps) => {
   const classes = useStyles();
 
   const colorCode = code.split('').map((char, i) => {
-    let charColor = 'inherit';
+    let charColor = WHITE;
     if (!Number.isNaN(char * 1)) {
       charColor = GOLD_LIGHT;
     } else if (char === char.toUpperCase()) {

--- a/app/components/ShortCode.tsx
+++ b/app/components/ShortCode.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 
 import { Box } from '@material-ui/core';
 
-import { GOLD_DARK, GOLD_LIGHT } from '../constants/colors';
+import { GOLD_DARK, GOLD_LIGHT, WHITE } from '../constants/colors';
 import {
   LUCKY_ARRAY_INDEX,
   LUCKY_ARRAY_END_INDEX,
@@ -29,9 +29,9 @@ const ShortCode: FC<ShortCodeProps> = ({ code }: ShortCodeProps) => {
 
   codeIndicies.forEach((luck) => {
     if (colorPairs.length === 4) {
-      colorPairs.push(['-', 'inherit']);
+      colorPairs.push(['-', WHITE]);
     }
-    let charColor = 'inherit';
+    let charColor = WHITE;
     if (!Number.isNaN(code.charAt(luck) * 1)) {
       charColor = GOLD_LIGHT;
     } else if (code.charAt(luck) === code.charAt(luck).toUpperCase()) {

--- a/app/constants/colors.ts
+++ b/app/constants/colors.ts
@@ -1,4 +1,3 @@
-// const platinum = '#ADB0BB'; // get rid of this
 export const BLACK = '#292A2D';
 export const BLACK_DARK = '#202124';
 export const GOLD_DARK = '#BA9236';


### PR DESCRIPTION
Soundtrack of this PR: [Yung Gravy - oops! (Official Video)](https://www.youtube.com/watch?v=NIdWvUuEBB0)

### Motivation :woman_facepalming:

Oops.. this definitely could've been included in the previous PR since the other 'inherit' props I was about to change are actually just for breadcrumbs/links. It'd probably be best to leave them as is for now in case we decide to change color scheme in the future, it'll be one less thing to be concerned with.

### In this PR

- Replaced inherit prop for character code colors with a const
- Deleted superfluous platinum const

### Screen Shots

| Screen Name                                             | Before | After |
| :------------------------------------------------------ | :----: | :---: |
| AccountCard |<img width="1239" alt="Screen Shot 2021-03-05 at 2 18 13 PM" src="https://user-images.githubusercontent.com/22161142/110169017-ac6c4600-7dbd-11eb-864d-7a612563f83e.png">|<img width="1239" alt="Screen Shot 2021-03-05 at 2 15 36 PM" src="https://user-images.githubusercontent.com/22161142/110169034-b3935400-7dbd-11eb-89f1-7d29ede17be9.png">|