### PR TITLE
Test/wait to open binary - PLEASE DO NOT DELETE OR CLOSE

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -249,6 +249,10 @@ app.on('activate', () => {
  * Add custom message listeners...
  */
 
+ipcMain.on('logged-in', (_event, password) => {
+  console.log('THE USER LOGGED IN WITH PASSWORD=', password);
+});
+
 ipcMain.on('close-app', () => {
   app.quit();
 });

--- a/app/menus/otherMenu.js
+++ b/app/menus/otherMenu.js
@@ -66,10 +66,14 @@ const defaultTemplate = (app, mainWindow, i18n) => {
   if (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true') {
     submenuViewProd.submenu.push({
       accelerator: 'Alt+Command+I',
-      click: () => {
-        mainWindow.webContents.toggleDevTools();
-      },
+      click: () => mainWindow.webContents.toggleDevTools(),
       label: 'Toggle Developer Tools',
+    });
+
+    submenuViewProd.submenu.push({
+      accelerator: 'Command+R',
+      click: () => mainWindow.webContents.reload(),
+      label: 'Reload',
     });
   }
 

--- a/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
+++ b/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { FC } from 'react';
 
 import { Box, FormHelperText } from '@material-ui/core';
-import { ipcRenderer } from 'electron';
+// import { ipcRenderer } from 'electron';
 import { Formik, Form, Field } from 'formik';
 import type { FormikHelpers } from 'formik';
 import { TextField } from 'formik-material-ui';
@@ -35,7 +35,8 @@ export const unlockWalletFormOnSubmit = async (
 
   try {
     await unlockWallet(password);
-    ipcRenderer.send('logged-in', password);
+    // TODO: remove comment from next line to load binary at later time
+    // ipcRenderer.send('logged-in', password);
     if (isMountedRef.current) {
       setStatus({ success: true });
       setSubmitting(false);

--- a/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
+++ b/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { FC } from 'react';
 
 import { Box, FormHelperText } from '@material-ui/core';
+import { ipcRenderer } from 'electron';
 import { Formik, Form, Field } from 'formik';
 import type { FormikHelpers } from 'formik';
 import { TextField } from 'formik-material-ui';
@@ -34,6 +35,7 @@ export const unlockWalletFormOnSubmit = async (
 
   try {
     await unlockWallet(password);
+    ipcRenderer.send('logged-in', password);
     if (isMountedRef.current) {
       setStatus({ success: true });
       setSubmitting(false);

--- a/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
+++ b/app/views/auth/UnlockWalletView/UnlockWalletForm.tsx
@@ -62,8 +62,8 @@ const UnlockWalletForm: FC<UnlockWalletFormProps> = ({ onSubmit }: UnlockWalletF
     values: UnlockWalletFormValues,
     helpers: FormikHelpers<UnlockWalletFormValues>
   ) => {
-    const pseduoProps = { isMountedRef, unlockWallet };
-    onSubmit(pseduoProps, values, helpers);
+    const pseudoProps = { isMountedRef, unlockWallet };
+    onSubmit(pseudoProps, values, helpers);
   };
 
   const initialValues = {

--- a/test/views/wallet/TransactionView/__snapshots__/TransactionView.test.tsx.snap
+++ b/test/views/wallet/TransactionView/__snapshots__/TransactionView.test.tsx.snap
@@ -178,6 +178,7 @@ exports[`TransactionView component render TransactionView renders correctly 1`] 
                             >
                               <span
                                 class="MuiBox-root MuiBox-root"
+                                style="color: rgb(255, 255, 255);"
                               >
                                 b
                               </span>
@@ -201,26 +202,31 @@ exports[`TransactionView component render TransactionView renders correctly 1`] 
                               </span>
                               <span
                                 class="MuiBox-root MuiBox-root"
+                                style="color: rgb(255, 255, 255);"
                               >
                                 -
                               </span>
                               <span
                                 class="MuiBox-root MuiBox-root"
+                                style="color: rgb(255, 255, 255);"
                               >
                                 c
                               </span>
                               <span
                                 class="MuiBox-root MuiBox-root"
+                                style="color: rgb(255, 255, 255);"
                               >
                                 o
                               </span>
                               <span
                                 class="MuiBox-root MuiBox-root"
+                                style="color: rgb(255, 255, 255);"
                               >
                                 d
                               </span>
                               <span
                                 class="MuiBox-root MuiBox-root"
+                                style="color: rgb(255, 255, 255);"
                               >
                                 e
                               </span>


### PR DESCRIPTION
Soundtrack of this PR: ["Thus spake Zarathustra", from the opening of the "2001" movie](https://www.youtube.com/watch?v=BekjyAH7c2A)

### Motivation

A request to look into how the main process could learn that the user had successfully logged in. In the future, starting the binary would be done at that point, and not at the beginning of the app.

### In this PR

Display a log message after the user has logged in -- but the message is displayed after an event is captured in the main part of the app, not in the renderer.

### Caveats

No changes were done to the actual launching.

### Future Work

Launch the binary at a later time.

### Screen Shots

None needed.

### Testing

All tests pass.