### PR TITLE
Add margin to QRCode

### DIFF
--- a/app/components/QRMob.tsx
+++ b/app/components/QRMob.tsx
@@ -44,7 +44,7 @@ const QRMob: FC<QRMobProps> = (props) => {
 
   return (
     <Box className={classes.container}>
-      <QRCode className={classes.qr} level="H" {...props} />
+      <QRCode className={classes.qr} includeMargin level="H" {...props} />
       <Box className={classes.icon}>
         <CircleStrokeMOBIcon color="black" height={64} width={64} />
       </Box>

--- a/app/contexts/FullServiceContext.tsx
+++ b/app/contexts/FullServiceContext.tsx
@@ -506,7 +506,7 @@ export const FullServiceProvider: FC<FullServiceProviderProps> = ({
           selectedAccount: {
             account,
             balanceStatus,
-            mobUrl: `https://mobilecoin.com/mob58/${accountId}`,
+            mobUrl: `mob:///b58/${accountId}`,
           },
           walletStatus,
         },
@@ -556,7 +556,7 @@ export const FullServiceProvider: FC<FullServiceProviderProps> = ({
           selectedAccount: {
             account,
             balanceStatus,
-            mobUrl: `https://mobilecoin.com/mob58/${accountId}`,
+            mobUrl: `mob:///b58/${accountId}`,
           },
           walletStatus,
         },
@@ -677,7 +677,7 @@ export const FullServiceProvider: FC<FullServiceProviderProps> = ({
         selectedAccount: {
           account: selectedAccount.account,
           balanceStatus,
-          mobUrl: `https://mobilecoin.com/mob58/${accountId}`,
+          mobUrl: `mob:///b58/${accountId}`,
         },
         walletStatus,
       },
@@ -728,7 +728,7 @@ export const FullServiceProvider: FC<FullServiceProviderProps> = ({
           selectedAccount: {
             account: selectedAccount,
             balanceStatus,
-            mobUrl: `https://mobilecoin.com/mob58/${selectedAccount.accountId}`,
+            mobUrl: `mob:///b58/${selectedAccount.accountId}`,
           },
           walletStatus,
         },
@@ -799,7 +799,7 @@ export const FullServiceProvider: FC<FullServiceProviderProps> = ({
           selectedAccount: {
             account: selectedAccount.account,
             balanceStatus,
-            mobUrl: `https://mobilecoin.com/mob58/${accountId}`,
+            mobUrl: `mob:///b58/${accountId}`,
           },
           walletStatus,
         },

--- a/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
+++ b/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
@@ -477,7 +477,7 @@ const BuildGiftForm: FC = () => {
                       isGift
                       account={{
                         b58Code: confirmation?.giftCodeB58,
-                        mobUrl: `https://mobilecoin.com/mob58/${confirmation?.giftCodeB58}`,
+                        mobUrl: `mob:///b58/${confirmation?.giftCodeB58}`,
                         name: t('pending'),
                       }}
                     />

--- a/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftPanel.tsx
+++ b/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftPanel.tsx
@@ -186,7 +186,7 @@ const BuildGiftPanel: FC = () => {
                 isGift
                 account={{
                   b58Code: pendingDeleteCode[0],
-                  mobUrl: `https://mobilecoin.com/mob58/${pendingDeleteCode[0]}`,
+                  mobUrl: `mob:///b58/${pendingDeleteCode[0]}`,
                   name: 'Gift Code',
                 }}
               />


### PR DESCRIPTION
Soundtrack of this PR: [2Pac - Changes (Official Music Video) ft. Talent](https://www.youtube.com/watch?v=eXvBjCO19QY)

### Motivation :jigsaw:

QR codes in dark mode were no longer working, this is a fix to return functionality.

### In this PR

- includeMargin prop added to QRCode component

### Screen Shots

| Screen Name                                             | After | Before |
| :------------------------------------------------------ | :----: | :---: |
| QRMob |<img width="1198" alt="Screen Shot 2021-03-18 at 2 18 49 PM" src="https://user-images.githubusercontent.com/22161142/111687259-12ae8b00-87f8-11eb-8376-233de739321b.png">|<img width="1198" alt="Screen Shot 2021-03-18 at 2 19 11 PM" src="https://user-images.githubusercontent.com/22161142/111687310-20fca700-87f8-11eb-84fe-6827f233cb8d.png">|