### PR TITLE
Forcing react-number-format to version 4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.12.21",
     "react-i18next": "^11.8.5",
-    "react-number-format": "^4.4.1",
+    "react-number-format": "4.4.4",
     "react-router-dom": "^5.2.0",
     "react-transition-group": "^4.4.1",
     "regenerator-runtime": "^0.13.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13508,10 +13508,10 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-number-format@^4.4.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.5.0.tgz#3fc7b544530cf953a858c1d7a585f12e4ef6095e"
-  integrity sha512-QnZpikIClOZEDSLJciUl3qDvguQn+jOO/b3dqBimnHRN4qNan8mo4/9iVM7QC6YwqpHQ9lg5I3yFB6bBVusdhw==
+react-number-format@4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.4.4.tgz#2a7f50be404f990ec15855cc6babfeae1be16351"
+  integrity sha512-/MuF1GOs1Z0xBaQie8+TTqCxUTT8xxjc6RqIFVWcWB6FM8GNIenSh2ayzN6Y1J2WMcXUDVwMdDXjweHKVjXm/w==
   dependencies:
     prop-types "^15.7.2"
 


### PR DESCRIPTION
version 4.5.0+ is causing a catastrophic issue where when you send MOB under a certain amount (0.001, I think) it underflows and sets your MOB to the hundreds.