### PR TITLE
Warn user if closing unsynced app

### DIFF
--- a/app/layouts/DashboardLayout/TopBar/SyncStatus.tsx
+++ b/app/layouts/DashboardLayout/TopBar/SyncStatus.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { FC } from 'react';
 
 import { Box, makeStyles, Tooltip, CircularProgress } from '@material-ui/core';
+import { ipcRenderer } from 'electron';
 import { useTranslation } from 'react-i18next';
 
 import { CircleMOBIcon } from '../../../components/icons';
@@ -77,6 +78,7 @@ const SyncStatus: FC = () => {
     percentSynced = getPercentSyncedNew(networkBlockIndexBigInt, accountBlockIndexBigInt);
     statusCode = isSynced ? SYNCED : SYNCING;
   }
+  ipcRenderer.send('sync-status', statusCode);
 
   switch (statusCode) {
     case SYNCED: {

--- a/locales/enUS/translation.json
+++ b/locales/enUS/translation.json
@@ -108,6 +108,13 @@
     "settingsBreadcrumb": "Settings"
   },
 
+  "CloseApp": {
+    "confirm": "Synchronize in the background?",
+    "explain": "The ledger isn't totally synchronized yet. Do you want to leave the process synchronizing in the background?",
+    "no": "No, close anyway",
+    "yes": "Yes, let it run"
+  },
+
   "CloseWalletModal": {
     "closeVerifyBody": "Do you want to close and secure the wallet?",
     "closeVerifyConfirm": "Yes, Close Wallet",


### PR DESCRIPTION
Soundtrack of this PR: [If you leave me now](https://www.youtube.com/watch?v=-9_d-sFhmRM)

### Motivation

Allow the app to keep synchronizing by asking the user if need be.

### In this PR

When closing, check if the app isn't synced, and also not set to run in the background. If so, ask (beg! implore!!) the user to leave the service running in the background.

### Caveats

None

### Future Work

None

### Screen Shots

None - and format of window depends on OS.

### Testing

Tests all fail.