### PR TITLE
feature / Save to contact from SendMobForm

### DIFF
--- a/app/utils/LocalStore.ts
+++ b/app/utils/LocalStore.ts
@@ -50,9 +50,9 @@ export const setStore = (newStore: Store): void => {
 
 // CBB not sure if this needs to be stringified.
 export const getContacts = (): Contact[] =>
-  JSON.parse((store.get(schemaKeys.CONTACTS) as string) || '[]') as Contact[];
+  JSON.parse((store.get(schemaKeys.CONTACTS) as string) || '[]');
 
-export const setContacts = (contacts: []): void => {
+export const setContacts = (contacts: Contact[]): void => {
   store.set(schemaKeys.CONTACTS, JSON.stringify(contacts));
 };
 

--- a/app/views/wallet/TransactionView/SendMobPanel/SendMobForm.tsx
+++ b/app/views/wallet/TransactionView/SendMobPanel/SendMobForm.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Button,
   Fade,
-  FormControlLabel,
   FormHelperText,
   FormLabel,
   InputAdornment,
@@ -14,13 +13,12 @@ import {
   Slide,
   MenuItem,
   Modal,
-  Radio,
   Select,
   Typography,
   makeStyles,
 } from '@material-ui/core';
 import { Formik, Form, Field } from 'formik';
-import { CheckboxWithLabel, RadioGroup, TextField } from 'formik-material-ui';
+import { CheckboxWithLabel, TextField } from 'formik-material-ui';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
@@ -121,10 +119,9 @@ const SendMobForm: FC = () => {
   const classes = useStyles();
   const [confirmation, setConfirmation] = useState(EMPTY_CONFIRMATION);
   const { t } = useTranslation('SendMobForm');
-
   const [contactId, setContactId] = useState('');
   const [open, setOpen] = useState(false);
-  const [checked, setChecked] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
   const [isAwaitingConformation, setIsAwaitingConformation] = useState(false);
   const [sendingOpen, setSendingOpen] = useState(false);
   const [slideExitSpeed, setSlideExitSpeed] = useState(0);
@@ -156,26 +153,24 @@ const SendMobForm: FC = () => {
   ];
 
   const handleChecked = () => {
-    setChecked(!checked);
+    setIsChecked(!isChecked);
   };
 
   //* ****TODO: Fix math.random + Add to util******
-  const saveToContacts = async (values, nualias, recipientAddress) => {
+  const saveToContacts = async (alias: string, recipientAddress: string) => {
     const result = await assignAddressForAccount({
       accountId: selectedAccount.account.accountId || Math.random(),
     });
-    console.log(values);
-    console.log(nualias);
+
     listOfAllContacts.push({
       abbreviation: '',
-      alias: nualias,
+      alias,
       assignedAddress: result.address.publicAddress,
       isFavorite: false,
       recipientAddress,
     });
-    console.log(listOfAllContacts);
+
     localStore.setContacts(listOfAllContacts);
-    // debugger
   };
 
   const handleOpen = (values, setStatus, setErrors) => async () => {
@@ -346,8 +341,7 @@ const SendMobForm: FC = () => {
               confirmation?.totalValueConfirmation?.toString()
             );
             const totalValueConfirmationAsMobComma = commafy(totalValueConfirmationAsMob);
-
-            saveToContacts(values, values.alias, values.recipientPublicAddress);
+            saveToContacts(values.alias, values.recipientPublicAddress);
             enqueueSnackbar(`${t('success')} ${totalValueConfirmationAsMobComma} ${t('mob')}!`, {
               variant: 'success',
             });
@@ -408,7 +402,6 @@ const SendMobForm: FC = () => {
           totalSent = confirmation?.totalValueConfirmation + confirmation?.feeConfirmation;
         }
 
-        // const sortedContacts = [...listOfContacts].sort((a, b) => {
         const sortedContacts = [...listOfContacts].sort((a, b) => {
           if (a.isFavorite !== b.isFavorite) {
             return a.isFavorite ? -1 : 1;
@@ -423,7 +416,6 @@ const SendMobForm: FC = () => {
               <FormLabel component="legend">
                 <Typography color="primary">{t('transaction')}</Typography>
               </FormLabel>
-
               {listOfContacts.length > 0 && (
                 <Select
                   style={{ width: '100%' }}
@@ -490,25 +482,20 @@ const SendMobForm: FC = () => {
                 component={CheckboxWithLabel}
                 type="checkbox"
                 name="checked"
-                checked={checked}
+                checked={isChecked}
                 onChange={handleChecked}
                 disabled={contactId !== NO_CONTACT_SELECTED}
                 Label={{ label: 'Save to contacts' }}
               />
-              {checked && (
+              {isChecked && (
                 <Field
                   component={TextField}
                   fullWidth
                   autoFocus
-                  // label={t('recipient')}
                   label="Contact Alias"
                   margin="normal"
                   name="alias"
                   type="text"
-                  // value={alias}
-                  // onChange={(x) => {
-                  //   setAlias(x.target.value);
-                  // }}
                 />
               )}
             </Box>


### PR DESCRIPTION
Soundtrack of this PR: [Nipsey Hussle - Grinding All My Life / Stucc In The Grind (Official Video)](https://www.youtube.com/watch?v=AVrNHI4RdPM)

### Motivation :checkered_flag:

The Marathon Continues.. for incrementally improving Desktop Wallet!

### In this PR

- Adds the ability to save a contact to Contact Book for a Public Address directly from Send MOB Form.

### Caveats

- Adding the contact works but isn't updated in the ContactBookView until wallet is closed and reopened....

### Future Works

- The reason for the lag in the update is because Contacts aren't currently being managed by context (duhh), so that will be rectified in the near future.

### Screen Shots

| Screen Name                                             | After | Before |
| :------------------------------------------------------ | :----: | :---: |
| SendMOBForm |<img width="1106" alt="Screen Shot 2021-04-02 at 5 11 13 PM" src="https://user-images.githubusercontent.com/22161142/113458322-93b07980-93d7-11eb-9411-a33f1ff3023a.png">|<img width="1106" alt="Screen Shot 2021-04-02 at 5 12 02 PM" src="https://user-images.githubusercontent.com/22161142/113458341-9dd27800-93d7-11eb-9c73-55ce217751fa.png">|

