### PR TITLE
Fix modal copy for light theme

### DIFF
--- a/app/views/wallet/DashboardView/CloseWalletModal.tsx
+++ b/app/views/wallet/DashboardView/CloseWalletModal.tsx
@@ -71,10 +71,10 @@ const CloseWalletModal: FC = () => {
       >
         <Fade in={open}>
           <Box className={classes.paper}>
-            <Typography variant="h2" gutterBottom>
+            <Typography color="textPrimary" variant="h2" gutterBottom>
               {t('closeVerifyHeader')}
             </Typography>
-            <Typography variant="body2" gutterBottom>
+            <Typography color="textPrimary" variant="body2" gutterBottom>
               {t('closeVerifyBody')}
             </Typography>
             <Box display="flex">

--- a/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
+++ b/app/views/wallet/GiftingView/BuildGiftPanel/BuildGiftForm.tsx
@@ -76,7 +76,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.background.paper,
     border: '2px solid #000',
     boxShadow: theme.shadows[5],
+    margin: '4rem',
+    maxHeight: '-webkit-fill-available',
     maxWidth: 800,
+    overflow: 'auto',
     padding: theme.spacing(2, 4, 3),
   },
   root: {},
@@ -407,9 +410,8 @@ const BuildGiftForm: FC = () => {
                     <Typography variant="h1" color="textPrimary">
                       {t('giftConfirmation')}
                     </Typography>
-                    <Typography variant="p" color="textPrimary">
-                      {t('giftConfirmationDescription')}:
-                    </Typography>
+                    {/* <Typography variant="p" color="textPrimary"> */}
+                    <Typography color="textPrimary">{t('giftConfirmationDescription')}:</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
                     <Typography color="textPrimary">{t('accountBalance')}:</Typography>
@@ -464,8 +466,8 @@ const BuildGiftForm: FC = () => {
                     <Typography color="textPrimary">---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography color="textPrimary">{t('remaining')}:</Typography>
-                    <Typography color="textPrimary">
+                    <Typography color="primary">{t('remaining')}:</Typography>
+                    <Typography color="primary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"
@@ -504,7 +506,7 @@ const BuildGiftForm: FC = () => {
                       type="password"
                     />
                   )}
-                  <Box display="flex" justifyContent="space-between">
+                  <Box display="flex" justifyContent="space-between" style={{ padding: '1rem' }}>
                     <Button
                       className={classes.button}
                       color="secondary"

--- a/app/views/wallet/GiftingView/ConsumeGiftPanel/ConsumeGiftForm.tsx
+++ b/app/views/wallet/GiftingView/ConsumeGiftPanel/ConsumeGiftForm.tsx
@@ -313,13 +313,13 @@ const ConsumeGiftForm: FC = () => {
             >
               <Slide in={showModal} timeout={{ enter: 0, exit: 0 }}>
                 <Container className={classes.paper}>
-                  <Typography variant="h1" id="transition-modal-title">
+                  <Typography color="textPrimary" variant="h1" id="transition-modal-title">
                     {t('giftConfirmation')}
                   </Typography>
                   <Box py={2} />
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>{t('accountBalance')}:</Typography>
-                    <Typography>
+                    <Typography color="textPrimary">{t('accountBalance')}:</Typography>
+                    <Typography color="textPrimary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"
@@ -328,12 +328,12 @@ const ConsumeGiftForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>---</Typography>
-                    <Typography>---</Typography>
+                    <Typography color="textPrimary">---</Typography>
+                    <Typography color="textPrimary">---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>{t('total')}:</Typography>
-                    <Typography>
+                    <Typography color="textPrimary">{t('total')}:</Typography>
+                    <Typography color="textPrimary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"
@@ -342,8 +342,8 @@ const ConsumeGiftForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>{t('fee')}:</Typography>
-                    <Typography>
+                    <Typography color="textPrimary">{t('fee')}:</Typography>
+                    <Typography color="textPrimary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"

--- a/app/views/wallet/TransactionView/SendMobPanel/SendMobForm.tsx
+++ b/app/views/wallet/TransactionView/SendMobPanel/SendMobForm.tsx
@@ -46,7 +46,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   button: { width: 200 },
   center: { display: 'flex', justifyContent: 'center' },
   code: {
-    alignItems: 'center',
     display: 'flex',
     flexDirection: 'column',
     letterSpacing: '.70rem',
@@ -509,14 +508,16 @@ const SendMobForm: FC = () => {
             >
               <Slide in={open} timeout={{ enter: 0, exit: slideExitSpeed }}>
                 <div className={classes.paper}>
-                  <Typography variant="h2" id="transition-modal-title">
+                  <Typography color="textPrimary" variant="h2" id="transition-modal-title">
                     {t('confirm')}
                   </Typography>
-                  <Typography id="transition-modal-description">{t('intent')}:</Typography>
+                  <Typography color="textPrimary" id="transition-modal-description">
+                    {t('intent')}:
+                  </Typography>
                   <br />
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>{t('accountBalance')}:</Typography>
-                    <Typography>
+                    <Typography color="textPrimary">{t('accountBalance')}:</Typography>
+                    <Typography color="textPrimary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"
@@ -525,8 +526,8 @@ const SendMobForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>---</Typography>
-                    <Typography>---</Typography>
+                    <Typography color="textPrimary">---</Typography>
+                    <Typography color="textPrimary">---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
                     <Typography color="primary">{t('amount')}:</Typography>
@@ -539,8 +540,8 @@ const SendMobForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>{t('fee')}:</Typography>
-                    <Typography>
+                    <Typography color="textPrimary">{t('fee')}:</Typography>
+                    <Typography color="textPrimary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"
@@ -549,8 +550,8 @@ const SendMobForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>{t('total')}:</Typography>
-                    <Typography>
+                    <Typography color="textPrimary">{t('total')}:</Typography>
+                    <Typography color="textPrimary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"
@@ -559,12 +560,12 @@ const SendMobForm: FC = () => {
                     </Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>---</Typography>
-                    <Typography>---</Typography>
+                    <Typography color="textPrimary">---</Typography>
+                    <Typography color="textPrimary">---</Typography>
                   </Box>
                   <Box display="flex" justifyContent="space-between">
-                    <Typography>{t('remaining')}:</Typography>
-                    <Typography>
+                    <Typography color="primary">{t('remaining')}:</Typography>
+                    <Typography color="primary">
                       <MOBNumberFormat
                         suffix=" MOB"
                         valueUnit="pMOB"
@@ -577,13 +578,17 @@ const SendMobForm: FC = () => {
                     <Box width="50%" padding="1rem">
                       <Box>
                         {contactName !== '' ? (
-                          <Typography className={classes.center}>
+                          <Typography color="textPrimary" className={classes.center}>
                             {truncateContact(contactName, 15)}
                           </Typography>
                         ) : (
-                          <Typography className={classes.center}>{t('recipientPlus1')}</Typography>
+                          <Typography color="textPrimary" className={classes.center}>
+                            {t('recipientPlus1')}
+                          </Typography>
                         )}
-                        <Typography className={classes.center}>{t('recipientPlus2')}</Typography>
+                        <Typography color="textPrimary" className={classes.center}>
+                          {t('recipientPlus2')}
+                        </Typography>
                         <LongCode
                           code={confirmation?.txProposalReceiverB58Code}
                           codeClass={classes.code}
@@ -592,8 +597,12 @@ const SendMobForm: FC = () => {
                     </Box>
                     <Box width="50%" padding="1rem">
                       <Box>
-                        <Typography className={classes.center}>{t('senderPlus1')}</Typography>
-                        <Typography className={classes.center}>{t('senderPlus2')}</Typography>
+                        <Typography color="textPrimary" className={classes.center}>
+                          {t('senderPlus1')}
+                        </Typography>
+                        <Typography color="textPrimary" className={classes.center}>
+                          {t('senderPlus2')}
+                        </Typography>
                         <LongCode code={values.senderPublicAddress} codeClass={classes.code} />
                       </Box>
                     </Box>


### PR DESCRIPTION
Soundtrack of this PR: [DMX - First I'm Gonna Crawl (complete version)](https://www.youtube.com/watch?v=PBwh6zrcXa0)

### Motivation

Text for modals in light theme was illegible, this fix passes appropriate props to components to correct the issue.

### In this PR

- Pass in the correct Typography prop to CloseWalletModal, BuildGiftForm, ConsumeGiftForm, SendMobForm
- Fixes last row alignment in SendMobForm for LongCode
- Fix for BuildGiftForm to longer take up entire screen

### Screen Shots

| Screen Name                                             | Before | After |
| :------------------------------------------------------ | :----: | :---: |
| SendMobForm |<img width="812" alt="Screen Shot 2021-04-12 at 3 32 00 PM" src="https://user-images.githubusercontent.com/22161142/114463179-b5fd8080-9ba9-11eb-9987-e24b1740944b.png">|<img width="812" alt="Screen Shot 2021-04-12 at 3 48 43 PM" src="https://user-images.githubusercontent.com/22161142/114463232-c6156000-9ba9-11eb-8f4a-4dbe3e848279.png">|
