### PR TITLE
added support for new data type from full service

### DIFF
--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -24,7 +24,6 @@ const HistoryPage: FC = () => {
     contacts,
     selectedAccount,
     transactionLogs,
-    txos,
     fetchAllTransactionLogsForAccount,
     fetchAllTxosForAccount,
   } = useFullService();
@@ -84,17 +83,12 @@ const HistoryPage: FC = () => {
       );
 
     case DETAILS:
-      /*
-            We should get the TXOs for the transaction
-          */
-
       return (
         <TransactionDetailsView
           comment="this should come from metadata"
           onClickBack={() => setShowing(HISTORY)}
           onChangedComment={() => {}}
           transactionLog={currentTransactionLog}
-          txos={txos}
         />
       );
 

--- a/app/pages/History/TransactionDetails.view/TransactionDetails.d.ts
+++ b/app/pages/History/TransactionDetails.view/TransactionDetails.d.ts
@@ -1,10 +1,8 @@
 import type TransactionLog from '../../../types/TransactionLog';
-import type { Txos } from '../../../types/Txo';
 
 export interface TransactionDetailsViewProps {
   comment: string; // this should be from metadata
   onChangedComment: (transactionLogId: string, comment: string) => void;
   onClickBack: () => void;
   transactionLog: TransactionLog;
-  txos: Txos;
 }

--- a/app/pages/History/TransactionDetails.view/TransactionDetails.view.tsx
+++ b/app/pages/History/TransactionDetails.view/TransactionDetails.view.tsx
@@ -36,7 +36,6 @@ const TransactionDetails: FC<TransactionDetailsViewProps> = ({
   // onChangedComment,
   onClickBack,
   transactionLog,
-  txos,
 }: TransactionDetailsViewProps) => {
   const classes = useStyles();
   const { t } = useTranslation('TransactionDetails');
@@ -49,7 +48,7 @@ const TransactionDetails: FC<TransactionDetailsViewProps> = ({
     finalizedBlockIndex,
     assignedAddressId,
     recipientAddressId,
-    outputTxoIds,
+    outputTxos,
     // transactionLogId,
     valuePmob,
   } = transactionLog;
@@ -118,14 +117,10 @@ const TransactionDetails: FC<TransactionDetailsViewProps> = ({
           {t('txoDetails')}
         </Typography>
         <CardContent>
-          {outputTxoIds.map((txoId) =>
+          {outputTxos.map((txo) =>
             renderRow(
-              txoId,
-              <TransactionInfoLabel
-                valuePmob={txos.txoMap[txoId].valuePmob}
-                sign={sign}
-                label=" MOB"
-              />,
+              txo.txoIdHex,
+              <TransactionInfoLabel valuePmob={txo.valuePmob} sign={sign} label=" MOB" />,
               true
             )
           )}

--- a/app/types/TransactionLog.ts
+++ b/app/types/TransactionLog.ts
@@ -1,10 +1,11 @@
 import Contact from './Contact';
 import type { StringB58, StringHex, StringUInt64 } from './SpecialStrings';
+import type TxoAbbrev from './TxoAbbrev';
 
 export default interface TransactionLog {
   accountId: StringHex;
   assignedAddressId: StringB58;
-  changeTxoIds: StringHex[];
+  changeTxos: TxoAbbrev[];
   comment: string;
   contact?: Contact; // FIX-ME this is not from the full-service API, we should remove.
   direction: 'tx_direction_received' | 'tx_direction_sent';
@@ -12,11 +13,11 @@ export default interface TransactionLog {
   failureMessage: string | null;
   feePmob: StringUInt64 | null;
   finalizedBlockIndex: StringUInt64 | null;
-  inputTxoIds: StringHex[];
+  inputTxos: TxoAbbrev[];
   isSentRecovered: boolean | null;
   object: 'transaction_log';
   offsetCount: number;
-  outputTxoIds: StringHex[];
+  outputTxos: TxoAbbrev[];
   recipientAddressId: StringB58 | null;
   sentTime: string | null; // FIX-ME: Confirm type
   status:

--- a/app/types/TxoAbbrev.ts
+++ b/app/types/TxoAbbrev.ts
@@ -1,0 +1,8 @@
+import type { StringHex, StringUInt64 } from './SpecialStrings';
+
+export default interface TxoAbbrev {
+  object: 'txoAbbrev';
+  recipientAddressId: StringHex;
+  txoIdHex: StringHex;
+  valuePmob: StringUInt64;
+}


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Full Service is using a new format for transaction logs which changes out the input, output, and change txo id's with abbreviated versions of the txo details instead.

### In this PR

- Added TxoAbbrev and changed out where [type]TxoIds was being used to now use [type]Txos, and updated appropriate input params for Transaction Log and History.

### Caveats

None

### Future Work

None

### Testing
Not sure of the current status for running tests. @fktt22 updates on this? appreciate it :)
