### PR TITLE
transaction logs now sort on finalized block height

### DIFF
--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -52,11 +52,12 @@ const HistoryPage: FC = () => {
           }
           return transactionLog;
         })
-        .sort((a, b) => b.offsetCount - a.offsetCount);
+        .sort((a, b) => b.finalizedBlockIndex - a.finalizedBlockIndex);
     }
     return [] as TransactionLog[];
   };
 
+  console.log(buildList());
   // CREATE VIEW
 
   if (transactionLogs === null) {


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

The transactions were showing from oldest to newest, assuming this is not the intended functionality?

### In this PR

- Changed direction of sorting, and also now sorts on the finalized block height field

### Caveats

None

### Future Work

None