### PR TITLE
Clean up for previous PR

### DIFF
--- a/app/components/MOBNumberFormat/MOBNumberFormat.test.tsx
+++ b/app/components/MOBNumberFormat/MOBNumberFormat.test.tsx
@@ -4,11 +4,9 @@ import { screen, render } from '@testing-library/react';
 
 import '@testing-library/jest-dom/extend-expect';
 import { MOBNumberFormat } from './MOBNumberFormat.view';
-// import '../../testUtils/i18nForTests';
-// inputRef, onChange, name, value, valueUnit
 
 describe('MOBNumberFormat', () => {
-  test('renders positive transaction info label', () => {
+  test('renders formatted pMob value', () => {
     render(<MOBNumberFormat value="10" valueUnit="pMOB" prefix="+" suffix="received" />);
 
     expect(screen.getByText('+0.000000000010received')).toBeInTheDocument();

--- a/app/components/TermsOfUseDialog/TermsOfUseDialog.test.tsx
+++ b/app/components/TermsOfUseDialog/TermsOfUseDialog.test.tsx
@@ -1,7 +1,5 @@
-/* eslint-disable jest/no-commented-out-tests */
 import React from 'react';
 
-import 'jest-canvas-mock';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -11,11 +9,21 @@ import '../../testUtils/i18nForTests';
 
 const handleCloseTerms = jest.fn();
 describe('TermsOfUseDialog', () => {
-  test('renders long code with tooltip by default and toggles correctly', () => {
+  test('renders TermsOfUse and closes on click', () => {
     render(<TermsOfUseDialog open handleCloseTerms={handleCloseTerms} />);
+
+    expect(screen.getByTestId('tos-header').textContent).toEqual(
+      'MOBILECOIN TERMS OF USE FOR MOBILECOINS AND MOBILECOIN WALLETS'
+    );
 
     userEvent.click(screen.getByText('Close Terms of Use'));
 
     expect(handleCloseTerms).toHaveBeenCalled();
+  });
+
+  test('TermsOfUse not rendered if open prop is false', () => {
+    render(<TermsOfUseDialog open={false} handleCloseTerms={handleCloseTerms} />);
+
+    expect(screen.queryByTestId('tos-header')).toBeNull();
   });
 });


### PR DESCRIPTION
### Motivation

Removes commented out test imports, corrects a test description and adds test to TermsOfUseDialog.

### Caveats

- AccountCard test left commented out - will be good to run after Brians ipc refactor.