### PR TITLE
[MOBDW-53] Allow smaller window and reduce balance indicator

### DIFF
--- a/app/constants/app.ts
+++ b/app/constants/app.ts
@@ -1,7 +1,7 @@
 export const APP_VERSION = process.env.npm_package_version;
 
-export const MIN_WINDOW_HEIGHT = 900;
-export const MIN_WINDOW_WIDTH = 720;
+export const MIN_WINDOW_HEIGHT = 480;
+export const MIN_WINDOW_WIDTH = 480;
 
 export const HISTORY_PAGE_SIZE = 5; // for usage in Transaction History
 

--- a/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
+++ b/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: 25,
   },
   item: {
-    padding: theme.spacing(3, 0, 0, 0),
+    padding: theme.spacing(1, 0, 0, 0),
     textAlign: 'center',
   },
   valueContainer: {

--- a/app/layouts/DashboardLayout/DashboardLayout.presenter/DashboardLayout.presenter.tsx
+++ b/app/layouts/DashboardLayout/DashboardLayout.presenter/DashboardLayout.presenter.tsx
@@ -51,7 +51,7 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({ children, onClose }: Dashbo
     <Box className={classes.root}>
       <TopBar />
       <Box className={classes.wrapper}>
-        <Box display="flex" flexDirection="column" p={3}>
+        <Box display="flex" flexDirection="column" p={1}>
           <SyncStatus selectedAccount={selectedAccount} sendSyncStatus={sendSyncStatus} />
           <BalanceIndicator
             balance={selectedAccount.balanceStatus.unspentPmob}


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Solve bug reported by user

### In this PR

[MOBDW-53]

### Caveats

The balance indicator should be more responsive, and change design for smaller windows.

### Future Work

Redesign the balance indicator for smaller windows.

### Screen Shots

None

### Testing

```
Test Suites: 52 passed, 52 total
Tests:       134 passed, 134 total
Snapshots:   6 passed, 6 total
Time:        22.636 s, estimated 45 s
Ran all test suites.
Done in 24.32s.
```


[MOBDW-53]: https://mobilecoin.atlassian.net/browse/MOBDW-53