### PR TITLE
Hotfix/fix fk transaction log bug

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobilecoin-wallet",
   "productName": "MobileCoin Wallet",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Desktop hot wallet for your MobileCoin needs.",
   "main": "./main.prod.js",
   "author": {

--- a/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
+++ b/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
@@ -53,6 +53,7 @@ const SendReceivePage: FC = () => {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [sendingStatus, setSendingStatus] = useState(Showing.INPUT_FORM);
   const [confirmation, setConfirmation] = useState(EMPTY_CONFIRMATION);
+  const [includeAccountId, setIncludeAccountId] = useState(true);
   const [formIsChecked, setIsChecked] = useState(false);
   const [formAlias, setAlias] = useState('');
   const [formRecipientPublicAddress, setRecipientPublicAddress] = useState('');
@@ -109,7 +110,7 @@ const SendReceivePage: FC = () => {
   const onClickConfirm = () => {
     try {
       // fk setSlideExitSpeed(1000);
-      submitTransaction(confirmation.txProposal);
+      submitTransaction(confirmation.txProposal, includeAccountId);
 
       const totalValueConfirmationAsMob = convertPicoMobStringToMob(
         confirmation.totalValueConfirmation.toString()
@@ -164,6 +165,8 @@ const SendReceivePage: FC = () => {
       const { feeConfirmation, totalValueConfirmation, txProposal, txProposalReceiverB58Code } =
         result;
 
+      setIncludeAccountId(true);
+
       setConfirmation({
         feeConfirmation,
         totalValueConfirmation,
@@ -210,6 +213,7 @@ const SendReceivePage: FC = () => {
       ) {
         throw new Error(t('invalidTransaction'));
       }
+      setIncludeAccountId(false);
       setConfirmation(txConfirmation);
       setSendingStatus(Showing.CONFIRM_FORM);
     } catch (err) {

--- a/app/services/submitTransaction.service.ts
+++ b/app/services/submitTransaction.service.ts
@@ -2,9 +2,12 @@ import { store } from '../contexts/FullServiceContext';
 import * as fullServiceApi from '../fullService/api';
 import type { TxProposal } from '../types/TxProposal.d';
 
-const submitTransaction = async (txProposal: TxProposal): Promise<void> => {
+const submitTransaction = async (
+  txProposal: TxProposal,
+  includeAccountId = true
+): Promise<void> => {
   const { selectedAccount } = store.state;
-  const { accountId } = selectedAccount.account;
+  const accountId = includeAccountId ? selectedAccount.account.accountId : undefined;
   // submit transaction
   // TODO probably want to figure out what I want to save about this transaction log
   await fullServiceApi.submitTransaction({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobilecoin-wallet",
   "productName": "MobileCoin Wallet",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Desktop hot wallet for your MobileCoin needs.",
   "scripts": {
     "build": "concurrently \"yarn build-main\" \"yarn build-renderer\"",


### PR DESCRIPTION
No longer submits transaction to full service with an account id if grabbed from a tx confirmation. This will prevent full service from creating a tx log and running in to FK Constraints when it's restarted, preventing it from launching. There is a better, more complete fix coming down the line, but this is a fast hotfix until then.