### PR TITLE
HotFix for payment request modal not closing after send and resetting form

### DIFF
--- a/app/pages/SendReceive/PaymentRequests.view/PaymentRequest.d.ts
+++ b/app/pages/SendReceive/PaymentRequests.view/PaymentRequest.d.ts
@@ -5,7 +5,7 @@ export interface PaymentRequestProps {
   enqueueSnackbar: () => void;
   feePmob: string;
   onClickCancel: () => void;
-  onClickConfirm: () => void;
+  onClickConfirm: (resetForm: () => void) => void;
   // onClickViewPaymentRequest: () => void;
   selectedAccount: SelectedAccount;
 }

--- a/app/pages/SendReceive/PaymentRequests.view/PaymentRequest.view.tsx
+++ b/app/pages/SendReceive/PaymentRequests.view/PaymentRequest.view.tsx
@@ -124,6 +124,7 @@ const PaymentRequest: FC<PaymentRequestProps> = ({
         dirty,
         handleBlur,
         isValid,
+        resetForm,
         setFieldValue,
         submitForm,
         values,
@@ -321,7 +322,7 @@ const PaymentRequest: FC<PaymentRequestProps> = ({
                             className={classes.button}
                             color="secondary"
                             fullWidth
-                            onClick={onClickConfirm}
+                            onClick={() => onClickConfirm(resetForm)}
                             variant="contained"
                             id="claim-modal"
                           >


### PR DESCRIPTION
### Motivation 🐛 

Bug fix

### In this PR

- Updated type for PaymentRequest props and passed reset fn to click handler.
