### PR TITLE
update readme directions for startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ MobileCoin Desktop Wallet is available under open-source licenses. Look for the 
 
 ### Setup
 
-Depending on your local platform, you'll need to add the correct version from the Downloads section of the [full-service binaries](https://github.com/mobilecoinofficial/full-service/releases/tag/v1.0.0-pre.8) to the `./full-service-bin` directory. Grab the binary `full-service` file and the .css files, and place them in their relative subdirectory in `./full-service-bin`. Once you have the files in the `./full-service-bin/testnet` and `./full-service-bin/mainnet` directories, copy the contents from `./full-service-bin/testnet` into `./full-service-bin`. When you add the binaries, you will likely need to give permissions for the dev environment to run them. In the directory with the binaries, grant permission: `chmod +x full-service`.
+Depending on your local platform, you'll need to add the correct version from the Downloads section of the [full-service binaries](https://github.com/mobilecoinofficial/full-service/releases) to the `./full-service-bin` directory. Grab the binary `full-service` file and the .css files, and place them in their relative subdirectory in `./full-service-bin`. Once you have the files in the `./full-service-bin/testnet` and `./full-service-bin/mainnet` directories, copy the contents from `./full-service-bin/testnet` into `./full-service-bin`. When you add the binaries, you will likely need to give permissions for the dev environment to run them. In the directory with the binaries, grant permission: `chmod +x full-service`.
 
 ### Dev
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ MobileCoin Desktop Wallet is available under open-source licenses. Look for the 
 
 ### Setup
 
-Depending on your local platform, you'll need to add the correct version of [full-service binaries](https://github.com/mobilecoinofficial/full-service/releases/tag/v1.0.0-pre.8) to the `./full-service-bin` directory. If you add the binaries, you will likely need to give permissions for the dev environment to run them. In the directory with the binaries, grant permission: `chmod +x full-service`.
+Depending on your local platform, you'll need to add the correct version from the Downloads section of the [full-service binaries](https://github.com/mobilecoinofficial/full-service/releases/tag/v1.0.0-pre.8) to the `./full-service-bin` directory. Grab the binary `full-service` file and the .css files, and place them in their relative subdirectory in `./full-service-bin`. Once you have the files in the `./full-service-bin/testnet` and `./full-service-bin/mainnet` directories, copy the contents from `./full-service-bin/testnet` into `./full-service-bin`. When you add the binaries, you will likely need to give permissions for the dev environment to run them. In the directory with the binaries, grant permission: `chmod +x full-service`.
 
 ### Dev
 
-You'll need to start by installing the packages. At the root, run `yarn install` (or `yarn` if you're cool like that). Because this wallet has native packages, you'll need to drop into the app/ directory `cd app/` and run `yarn install` here as well. Once done, hop back up to the root directory (I know you know this, but `cd ..`).
+The application is dependent on using node version `^16.0.0`. Since different applications may rely on different versions of node, it is recommended you use a [node manager like n](https://github.com/tj/n). You can check the current node version with `node --version`.
 
-Run the dev environment with `yarn dev`.
+Once you're working with the correct version of node, you'll need to install the rest of the packages. At the root of the directory run `yarn install` (or `yarn` if you're cool like that). Because this wallet has native packages, you'll need to drop into the app/ directory `cd app/` and run `yarn install` here as well. Once done, hop back up to the root directory (I know you know this, but `cd ..`).
+
+Run the dev environment with `yarn dev` from the base directory.
 
 That's it!
 


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://open.spotify.com/track/0bXpmJyHHYPk6QBFj25bYF?si=7c56979722db4a74)

### Motivation

The README.md file had a few gaps in the setup instructions. In going through the environment setup process I wanted to update the instructions to match what was needed.

### In this PR

- updates instructions in the README.md

### Caveats


### Future Work

- Probably a good idea to have the next hire do a similar update if they find things out of date.

### Screen Shots

| Screen Name                                             | Before | After |
| :------------------------------------------------------ | :----: | :---: |
| <please always include, at least, a min and max screen> |        |       |

### Testing

 PASS  app/pages/NotFound/NotFound.test.tsx (5.262 s)
 PASS  app/pages/History/HistoryItem.view/HistoryItem.test.tsx (6.265 s)
 PASS  app/pages/History/HistoryList.view/HistoryList.test.tsx (6.73 s)
 PASS  app/pages/Contacts/ContactCard.view/ContactCard.test.tsx (7.02 s)
 PASS  app/pages/CrashReport/CrashShowLog.view/CrashShowLog.test.tsx
  ● Console

    console.error
      Warning: Failed prop type: The prop `rowsMax` of `ForwardRef(TextareaAutosize)` is deprecated. Use `maxRows` instead.
          at TextareaAutosize (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/TextareaAutosize/TextareaAutosize.js:48:24)
          at InputBase (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/InputBase/InputBase.js:219:30)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at Input (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Input/Input.js:137:32)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at FormControl (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/FormControl/FormControl.js:90:24)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at TextField (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/TextField/TextField.js:84:28)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at StyledComponent (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/styled/styled.js:95:28)
          at CrashShowLog (/Users/dalvarez/GitHub/desktop-wallet/app/pages/CrashReport/CrashShowLog.view/CrashShowLog.view.tsx:41:3)

      at printWarning (node_modules/react/cjs/react.development.js:220:30)
      at error (node_modules/react/cjs/react.development.js:196:5)
      at checkPropTypes (node_modules/react/cjs/react.development.js:1935:11)
      at validatePropTypes (node_modules/react/cjs/react.development.js:2136:7)
      at Object.createElementWithValidation [as createElement] (node_modules/react/cjs/react.development.js:2240:5)
      at InputBase (node_modules/@material-ui/core/InputBase/InputBase.js:461:25)
      at renderWithHooks (node_modules/react-dom/cjs/react-dom.development.js:14985:18)
      at updateForwardRef (node_modules/react-dom/cjs/react-dom.development.js:17044:20)

 PASS  app/pages/Contacts/ContactsList.view/ContactsList.test.tsx (8.741 s)
 PASS  app/pages/Settings/LedgerStatus.view/LedgerStatus.test.tsx
 PASS  app/pages/Settings/ShowRetrievedEntropy.view/ShowRetrievedEntropy.test.tsx
 PASS  app/pages/Settings/PrivacyPolicy.component/PrivacyPolicy.test.tsx
 PASS  app/pages/Settings/SettingsOptionsList.view/SettingsOptionsList.test.tsx
 PASS  app/pages/Settings/Accounts/AccountItem.view/AccountItem.test.tsx
 PASS  app/pages/Auth/CreateAccount.view/CreateAccount.test.tsx (13.517 s)
 PASS  app/pages/Settings/PrivacyPolicy.view/PrivacyPolicy.test.tsx
 PASS  app/pages/Dashboard/CloseWalletModal.view/CloseWalletModal.test.tsx (13.933 s)
 PASS  app/pages/Dashboard/DashboardPage.view/DashboardPage.test.tsx (14.029 s)
 PASS  app/pages/Settings/RetrieveEntropy.view/RetrieveEntropy.test.tsx (7.617 s)
 PASS  app/pages/Auth/UnlockWallet.view/UnlockWallet.test.tsx (14.893 s)
 PASS  app/pages/Gifts/ConsumeGiftForm.view/ConsumeGiftForm.test.tsx (15.145 s)
 PASS  app/pages/Settings/SettingsOptionsItem.view/SettingsOptionsItem.test.tsx
 PASS  app/pages/Settings/ConfigureFullService.view/ConfigureFullService.test.tsx
 PASS  app/pages/Gifts/BuildGiftPanel.view/BuildGiftPanel.test.tsx (15.715 s)
  ● Console

    console.error
      Warning: validateDOMNesting(...): <tr> cannot appear as a child of <div>.
          at tr
          at TableRow (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/TableRow/TableRow.js:67:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at Paper (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at Card (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Card/Card.js:34:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at TableHead (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/TableHead/TableHead.js:38:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at table
          at Table (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Table/Table.js:54:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at TableContainer (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/TableContainer/TableContainer.js:33:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at StyledComponent (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/styled/styled.js:95:28)
          at div
          at CardContent (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/CardContent/CardContent.js:35:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at Paper (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at Card (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Card/Card.js:34:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at StyledComponent (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/styled/styled.js:95:28)
          at div
          at Container (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Container/Container.js:92:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at BuildGiftPanel (/Users/dalvarez/GitHub/desktop-wallet/app/pages/Gifts/BuildGiftPanel.view/BuildGiftPanel.view.tsx:46:3)
          at SnackbarProvider (/Users/dalvarez/GitHub/desktop-wallet/node_modules/notistack/src/SnackbarProvider.tsx:30:9)

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at validateDOMNesting (node_modules/react-dom/cjs/react-dom.development.js:10081:7)
      at createInstance (node_modules/react-dom/cjs/react-dom.development.js:10181:5)
      at completeWork (node_modules/react-dom/cjs/react-dom.development.js:19464:28)
      at completeUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:22812:16)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:22787:5)
      at workLoopSync (node_modules/react-dom/cjs/react-dom.development.js:22707:5)

    console.error
      Warning: validateDOMNesting(...): <div> cannot appear as a child of <table>.
          at div
          at Paper (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at Card (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Card/Card.js:34:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at TableHead (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/TableHead/TableHead.js:38:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at table
          at Table (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Table/Table.js:54:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at TableContainer (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/TableContainer/TableContainer.js:33:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at StyledComponent (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/styled/styled.js:95:28)
          at div
          at CardContent (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/CardContent/CardContent.js:35:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at Paper (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at Card (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Card/Card.js:34:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at StyledComponent (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/styled/styled.js:95:28)
          at div
          at Container (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/core/Container/Container.js:92:23)
          at WithStyles (/Users/dalvarez/GitHub/desktop-wallet/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at BuildGiftPanel (/Users/dalvarez/GitHub/desktop-wallet/app/pages/Gifts/BuildGiftPanel.view/BuildGiftPanel.view.tsx:46:3)
          at SnackbarProvider (/Users/dalvarez/GitHub/desktop-wallet/node_modules/notistack/src/SnackbarProvider.tsx:30:9)

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at validateDOMNesting (node_modules/react-dom/cjs/react-dom.development.js:10081:7)
      at createInstance (node_modules/react-dom/cjs/react-dom.development.js:10181:5)
      at completeWork (node_modules/react-dom/cjs/react-dom.development.js:19464:28)
      at completeUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:22812:16)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:22787:5)
      at workLoopSync (node_modules/react-dom/cjs/react-dom.development.js:22707:5)

 PASS  app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.test.tsx
 PASS  app/layouts/DashboardLayout/TopBar/NavBar.view/NavBar.test.tsx
  ● Console

    console.error
      Material-UI: The value provided to the Tabs component is invalid.
      None of the Tabs' children match with `-1`.
      You can provide one of the following values: 0, 1, 2.

      at getTabsMeta (node_modules/@material-ui/core/Tabs/Tabs.js:221:21)
      at node_modules/@material-ui/core/Tabs/Tabs.js:238:24
      at node_modules/@material-ui/core/utils/useEventCallback.js:25:29
      at node_modules/@material-ui/core/Tabs/Tabs.js:398:5
      at invokePassiveEffectCreate (node_modules/react-dom/cjs/react-dom.development.js:23487:20)
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:3945:14)
      at HTMLUnknownElement.callTheUserObjectsOperation (node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
      at innerInvokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)

    console.error
      Material-UI: The value provided to the Tabs component is invalid.
      None of the Tabs' children match with `-1`.
      You can provide one of the following values: 0, 1, 2.

      at getTabsMeta (node_modules/@material-ui/core/Tabs/Tabs.js:221:21)
      at node_modules/@material-ui/core/Tabs/Tabs.js:326:25
      at node_modules/@material-ui/core/utils/useEventCallback.js:25:29
      at node_modules/@material-ui/core/Tabs/Tabs.js:402:5
      at invokePassiveEffectCreate (node_modules/react-dom/cjs/react-dom.development.js:23487:20)
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:3945:14)
      at HTMLUnknownElement.callTheUserObjectsOperation (node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
      at innerInvokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)

    console.error
      Material-UI: The value provided to the Tabs component is invalid.
      None of the Tabs' children match with `-1`.
      You can provide one of the following values: 0, 1, 2.

      at getTabsMeta (node_modules/@material-ui/core/Tabs/Tabs.js:221:21)
      at node_modules/@material-ui/core/Tabs/Tabs.js:238:24
      at node_modules/@material-ui/core/utils/useEventCallback.js:25:29
      at node_modules/@material-ui/core/Tabs/Tabs.js:398:5
      at invokePassiveEffectCreate (node_modules/react-dom/cjs/react-dom.development.js:23487:20)
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:3945:14)
      at HTMLUnknownElement.callTheUserObjectsOperation (node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
      at innerInvokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)

    console.error
      Material-UI: The value provided to the Tabs component is invalid.
      None of the Tabs' children match with `-1`.
      You can provide one of the following values: 0, 1, 2.

      at getTabsMeta (node_modules/@material-ui/core/Tabs/Tabs.js:221:21)
      at node_modules/@material-ui/core/Tabs/Tabs.js:326:25
      at node_modules/@material-ui/core/utils/useEventCallback.js:25:29
      at node_modules/@material-ui/core/Tabs/Tabs.js:402:5
      at invokePassiveEffectCreate (node_modules/react-dom/cjs/react-dom.development.js:23487:20)
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:3945:14)
      at HTMLUnknownElement.callTheUserObjectsOperation (node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
      at innerInvokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)

 PASS  app/pages/Settings/Accounts/DeleteAccountConfirmation.view/DeleteAccountConfirmation.test.tsx
  ● Console

    console.warn
      react-i18next:: You will need to pass in an i18next instance by using initReactI18next

      23 |   shortCode,
      24 | }: DeleteAccountConfirmationViewProps) => {
    > 25 |   const { t } = useTranslation('DeleteAccountConfirmationView');
         |                 ^
      26 |   return (
      27 |     <Formik
      28 |       initialValues={{

      at warn (node_modules/react-i18next/dist/commonjs/utils.js:22:31)
      at warnOnce (node_modules/react-i18next/dist/commonjs/utils.js:35:8)
      at useTranslation (node_modules/react-i18next/dist/commonjs/useTranslation.js:36:25)
      at DeleteAccountConfirmationView (app/pages/Settings/Accounts/DeleteAccountConfirmation.view/DeleteAccountConfirmation.view.tsx:25:17)
      at renderWithHooks (node_modules/react-dom/cjs/react-dom.development.js:14985:18)
      at mountIndeterminateComponent (node_modules/react-dom/cjs/react-dom.development.js:17811:13)
      at beginWork (node_modules/react-dom/cjs/react-dom.development.js:19049:16)
      at beginWork$1 (node_modules/react-dom/cjs/react-dom.development.js:23940:14)

 PASS  app/components/GlobalStyles/GlobalStyles.test.tsx
 PASS  app/layouts/DashboardLayout/OnboardingModal.view/OnboardingModal.test.tsx
 PASS  app/pages/SendReceive/ReceiveMob.view/ReceiveMob.test.tsx (17.53 s)
 PASS  app/layouts/DashboardLayout/SyncStatus.view/SyncStatus.test.tsx
 PASS  app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.test.tsx
  ● Console

    console.error
      Warning: An update to ShowEntropyModal inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at ShowEntropyModal (/Users/dalvarez/GitHub/desktop-wallet/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.view.tsx:45:3)

      71 |   const handleFinalConfirm = async () => {
      72 |     await confirmEntropyKnown();
    > 73 |     setAlertOpen(false);
         |     ^
      74 |   };
      75 |
      76 |   return (

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-dom/cjs/react-dom.development.js:24064:9)
      at setAlertOpen (node_modules/react-dom/cjs/react-dom.development.js:16135:9)
      at _callee$ (app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.view.tsx:73:5)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (node_modules/regenerator-runtime/runtime.js:119:21)

 PASS  app/components/TransactionInfoLabel/TransactionInfoLabel.test.tsx
 PASS  app/pages/Settings/TermsOfUse.view/TermsOfUse.test.tsx
 PASS  app/components/TabPanel/TabPanel.test.tsx
 PASS  app/components/SplashScreen/SplashScreen.test.tsx
 PASS  app/components/LongCode/LongCode.test.tsx
 PASS  app/components/LoadingScreen/LoadingScreen.test.tsx
 PASS  app/utils/convertMob.test.ts
 PASS  app/components/StarCheckbox/StarCheckbox.test.tsx
 PASS  app/utils/getPercentSynced.test.ts
 PASS  app/components/ShortCode/ShortCode.test.tsx
 PASS  app/utils/isValidPin.test.ts
 PASS  app/components/SubmitButton/SubmitButton.test.tsx
 PASS  app/components/TermsOfUse.component/TermsOfUse.test.tsx
 PASS  app/components/MOBNumberFormat/MOBNumberFormat.test.tsx
 PASS  app/constants/app.test.ts
 PASS  app/utils/bip39Functions.test.ts
 PASS  app/components/QRMob/QRMob.test.tsx
  ● Console

    console.warn
      Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.
      
      * Move data fetching code or side effects to componentDidUpdate.
      * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state
      * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
      
      Please update the following components: QRCodeCanvas

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at warn (node_modules/react-dom/cjs/react-dom.development.js:34:5)
      at Object.<anonymous>.ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings (node_modules/react-dom/cjs/react-dom.development.js:11530:7)
      at flushRenderPhaseStrictModeWarningsInDEV (node_modules/react-dom/cjs/react-dom.development.js:23822:31)
      at commitRootImpl (node_modules/react-dom/cjs/react-dom.development.js:23005:3)
      at unstable_runWithPriority (node_modules/scheduler/cjs/scheduler.development.js:468:12)
      at runWithPriority$1 (node_modules/react-dom/cjs/react-dom.development.js:11276:10)
      at commitRoot (node_modules/react-dom/cjs/react-dom.development.js:22990:3)

 PASS  app/components/TermsOfUse.dialog/TermsOfUseDialog.test.tsx
 PASS  app/layouts/DashboardLayout/SetPinModal.view/SetPinModal.test.tsx (5.771 s)
 PASS  app/components/AccountCard/AccountCard.test.tsx
  ● Console

    console.warn
      Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.
      
      * Move data fetching code or side effects to componentDidUpdate.
      * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state
      * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
      
      Please update the following components: QRCodeCanvas

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at warn (node_modules/react-dom/cjs/react-dom.development.js:34:5)
      at Object.<anonymous>.ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings (node_modules/react-dom/cjs/react-dom.development.js:11530:7)
      at flushRenderPhaseStrictModeWarningsInDEV (node_modules/react-dom/cjs/react-dom.development.js:23822:31)
      at commitRootImpl (node_modules/react-dom/cjs/react-dom.development.js:23005:3)
      at unstable_runWithPriority (node_modules/scheduler/cjs/scheduler.development.js:468:12)
      at runWithPriority$1 (node_modules/react-dom/cjs/react-dom.development.js:11276:10)
      at commitRoot (node_modules/react-dom/cjs/react-dom.development.js:22990:3)

 PASS  app/pages/Settings/ChangePin.view/ChangePin.test.tsx (7.489 s)
 PASS  app/pages/Auth/CreateWallet.view/CreateWallet.test.tsx (21.727 s)
 PASS  app/pages/Contacts/ContactForm.view/ContactForm.test.tsx (21.77 s)
 PASS  app/pages/Auth/ImportAccount.view/importAccount.test.tsx (23.149 s)
 PASS  app/pages/SendReceive/SendMob.view/SendMob.test.tsx (21.488 s)

Test Suites: 54 passed, 54 total
Tests:       137 passed, 137 total
Snapshots:   6 passed, 6 total
Time:        28.432 s
Ran all test suites.
✨  Done in 30.49s.
