### PR TITLE
Update web preferences

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,25 +24,3 @@ Soundtrack of this PR: [link to song that really fits the mood of this PR]()
 | Screen Name                                             | Before | After |
 | :------------------------------------------------------ | :----: | :---: |
 | <please always include, at least, a min and max screen> |        |       |
-
-### Testing
-
-< Copy and paste the results of `yarn test test/dir/files --coverage`>
-
-#### Example (Delete this):
-
-PASS test/fullService/api/getLockedStatus.test.ts
-PASS test/fullService/axiosFullService.test.ts
-File | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------|---------|----------|---------|---------|-------------------
-All files | 100 | 100 | 100 | 100 |
-fullService | 100 | 100 | 100 | 100 |
-axiosFullService.ts | 100 | 100 | 100 | 100 |
-fullService/api | 100 | 100 | 100 | 100 |
-getLockedStatus.ts | 100 | 100 | 100 | 100 |
-index.ts | 0 | 0 | 0 | 0 |
-
-Test Suites: 2 passed, 2 total
-Tests: 6 passed, 6 total
-Snapshots: 0 total
-Time: 3.436 s

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -166,13 +166,11 @@ const createWindow = async () => {
         ? {
             contextIsolation: false,
             disableBlinkFeatures: 'Auxclick',
-            enableRemoteModule: true,
             nodeIntegration: true,
           }
         : {
             contextIsolation: true,
             disableBlinkFeatures: 'Auxclick',
-            enableRemoteModule: true,
             nodeIntegration: false,
             nodeIntegrationInWorker: false,
             preload: path.join(__dirname, 'dist/renderer.prod.js'),

--- a/app/menus/otherMenu.js
+++ b/app/menus/otherMenu.js
@@ -11,7 +11,9 @@ const openAboutWindow = async (mainWindow) => {
     parent: mainWindow,
     title: '',
     webPreferences: {
-      nodeIntegration: true,
+      contextIsolation: true,
+      disableBlinkFeatures: 'Auxclick',
+      nodeIntegrationInWorker: false,
     },
     width: 300,
   });


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

[remoteModule: true is a bad practice, and now defaults to false](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31)
[contextIsolation is a planned breaking change](https://www.electronjs.org/docs/latest/breaking-changes) and helps separate out the electron environment and the web content environment, which improves security.
`disableBlinkFeatures: 'AuxClick'` turns off the ability to middle click links in electron. Middle clicking can run arbitrary javascript code, and presents a security hole.
`nodeIntegrationInWorker: false` If enabled, nodeIntegration allows JavaScript to leverage Node.js primitives
and modules. This could lead to full remote system compromise if you are
rendering untrusted content.


### In this PR

fixes tickets https://app.asana.com/0/1200242791884109/1201384503856762/f and https://app.asana.com/0/1200242791884109/1201384503856771/f

### Caveats

This ticket does not cover the `sandbox: true` settings. Updating this setting appears to require extensive webpack changes, and has been bumped due to unforeseen development cost. 

### Future Work

`sandbox: true` restricts the ability of code running in electron to interact with the user's computer. This is a security feature we should implement when we have time for it.
