### PR TITLE
FAB added to terms of use

### DIFF
--- a/app/components/TermsOfUse.dialog/TermsOfUseDialog.view.tsx
+++ b/app/components/TermsOfUse.dialog/TermsOfUseDialog.view.tsx
@@ -14,7 +14,11 @@ const useStyles = makeStyles({
       boxShadow:
         '0px 3px 5px -1px rgb(0 0 0 / 20%), 0px 6px 10px 0px rgb(0 0 0 / 14%), 0px 1px 18px 0px rgb(0 0 0 / 12%);',
     },
-    border: '4px solid #80808033',
+    '&:hover .MuiSvgIcon-root': {
+      fontSize: '3.5em',
+      transition: '0.1s ease-in-out',
+    },
+    border: '4px solid #00000014',
     borderRadius: '1em',
     bottom: 102,
     cursor: 'default',
@@ -41,14 +45,8 @@ const TermsOfUseDialog = (props: TermsOfUseDialogProps): JSX.Element => {
     >
       <Container maxWidth="md">
         <TermsOfUse />
-        <Fab
-          disableRipple
-          disableTouchRipple
-          disableFocusRipple
-          aria-label="Scroll Down"
-          className={classes.fab}
-        >
-          <ArrowDownwardIcon color="secondary" fontSize="large" />
+        <Fab disableRipple aria-label="Scroll Down" className={classes.fab} color="primary">
+          <ArrowDownwardIcon color="inherit" fontSize="large" />
         </Fab>
         <Box p={2}>
           <Button

--- a/app/components/TermsOfUse.dialog/TermsOfUseDialog.view.tsx
+++ b/app/components/TermsOfUse.dialog/TermsOfUseDialog.view.tsx
@@ -1,14 +1,33 @@
 import React from 'react';
 
-import { Box, Button, Container, Dialog } from '@material-ui/core';
+import { Box, Button, Container, Dialog, Fab } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import { useTranslation } from 'react-i18next';
 
 import { TermsOfUse } from '../TermsOfUse.component';
 import { TermsOfUseDialogProps } from './TermsOfUseDialog';
 
+const useStyles = makeStyles({
+  fab: {
+    '&:active': {
+      boxShadow:
+        '0px 3px 5px -1px rgb(0 0 0 / 20%), 0px 6px 10px 0px rgb(0 0 0 / 14%), 0px 1px 18px 0px rgb(0 0 0 / 12%);',
+    },
+    border: '4px solid #80808033',
+    borderRadius: '1em',
+    bottom: 102,
+    cursor: 'default',
+    height: '4em',
+    position: 'fixed',
+    right: 42,
+  },
+});
+
 const TermsOfUseDialog = (props: TermsOfUseDialogProps): JSX.Element => {
   const { open, handleCloseTerms } = props;
   const { t } = useTranslation('TermsOfUseDialog');
+  const classes = useStyles();
 
   return (
     <Dialog
@@ -22,6 +41,15 @@ const TermsOfUseDialog = (props: TermsOfUseDialogProps): JSX.Element => {
     >
       <Container maxWidth="md">
         <TermsOfUse />
+        <Fab
+          disableRipple
+          disableTouchRipple
+          disableFocusRipple
+          aria-label="Scroll Down"
+          className={classes.fab}
+        >
+          <ArrowDownwardIcon color="secondary" fontSize="large" />
+        </Fab>
         <Box p={2}>
           <Button
             color="secondary"


### PR DESCRIPTION
FAB:
<img width="890" alt="DW FAB" src="https://user-images.githubusercontent.com/22161142/148414488-2f0a779f-cc90-423f-8bc8-f8071d6bac00.png">
<img width="890" alt="DW FAB end" src="https://user-images.githubusercontent.com/22161142/148414491-895a4ce2-bb6f-4d5f-b724-c517ebb5b078.png">

FAB Hovered:
<img width="890" alt="DW FAB hover" src="https://user-images.githubusercontent.com/22161142/148414470-5d8539bf-974f-4edc-ab26-bad055fefb64.png">

