### PR TITLE
Tooltip added to Terms of Use FAB

### DIFF
--- a/app/components/TermsOfUse.dialog/TermsOfUseDialog.view.tsx
+++ b/app/components/TermsOfUse.dialog/TermsOfUseDialog.view.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Button, Container, Dialog, Fab } from '@material-ui/core';
+import { Box, Button, Container, Dialog, Fab, Tooltip } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import { useTranslation } from 'react-i18next';
@@ -45,9 +45,15 @@ const TermsOfUseDialog = (props: TermsOfUseDialogProps): JSX.Element => {
     >
       <Container maxWidth="md">
         <TermsOfUse />
-        <Fab disableRipple aria-label="Scroll Down" className={classes.fab} color="primary">
-          <ArrowDownwardIcon color="inherit" fontSize="large" />
-        </Fab>
+        <Tooltip
+          title='Scroll down and click "Close Terms Of Use" to confirm terms have been read.'
+          placement="top"
+          arrow
+        >
+          <Fab disableRipple aria-label="Scroll Down" className={classes.fab} color="primary">
+            <ArrowDownwardIcon color="inherit" fontSize="large" />
+          </Fab>
+        </Tooltip>
         <Box p={2}>
           <Button
             color="secondary"


### PR DESCRIPTION
### Motivation
Unequivocally ensure the user knows they should _Scroll down and click "Close Terms Of Use" to confirm terms have been read._
- Tooltip w/ scroll instructions (on hover) added to existing FAB Arrow 

### Screenshot
<img width="944" alt="Screen Shot 2022-01-24 at 11 11 20 AM" src="https://user-images.githubusercontent.com/22161142/150832857-bd730f29-0b81-47a7-b946-5ac0a1b3b792.png">
