### PR TITLE
TxProposal error (issue 127) fix, add type generics to axiosFullService

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
         pathGroupsExcludedImportTypes: ['react'],
       },
     ],
+    'import/prefer-default-export': 'off',
     'no-plusplus': ['off'],
     'no-unused-vars': [
       'error',

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,5 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.validate": [
-    "typescript"
-  ]
+  "eslint.validate": ["typescript"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,11 +6,9 @@
     ".dockerignore": "ignore",
     ".eslintignore": "ignore"
   },
-
   "javascript.validate.enable": false,
   "javascript.format.enable": false,
   "typescript.format.enable": false,
-
   "search.exclude": {
     ".git": true,
     ".eslintcache": true,
@@ -26,5 +24,11 @@
     "yarn.lock": true,
     "*.{css,sass,scss}.d.ts": true
   },
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.validate": [
+    "typescript"
+  ]
 }

--- a/app/fullService/api/assignAddressForAccount.ts
+++ b/app/fullService/api/assignAddressForAccount.ts
@@ -1,6 +1,6 @@
 import type { Address } from '../../types/Address.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const ASSIGN_ADDRESS_FOR_ACCOUNT_METHOD = 'assign_address_for_account';
 
@@ -17,17 +17,18 @@ const assignAddressForAccount = async ({
   accountId,
   metadata,
 }: AssignAddressForAccountParams): Promise<AssignAddressForAccountResult> => {
-  const { result, error } = await axiosFullService(ASSIGN_ADDRESS_FOR_ACCOUNT_METHOD, {
-    accountId,
-    metadata,
-  });
+  const { result, error }: AxiosFullServiceResponse<AssignAddressForAccountResult> =
+    await axiosFullService(ASSIGN_ADDRESS_FOR_ACCOUNT_METHOD, {
+      accountId,
+      metadata,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     const errorMessage = error === 'Database(PasswordFailed)' ? 'Incorrect Password' : error;
     throw new Error(errorMessage);
   } else {
-    return result;
+    return result as AssignAddressForAccountResult;
   }
 };
 

--- a/app/fullService/api/assignAddressForAccount.ts
+++ b/app/fullService/api/assignAddressForAccount.ts
@@ -27,8 +27,10 @@ const assignAddressForAccount = async ({
     // TODO - I'll write up a better error handler
     const errorMessage = error === 'Database(PasswordFailed)' ? 'Incorrect Password' : error;
     throw new Error(errorMessage);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as AssignAddressForAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/buildGiftCode.ts
+++ b/app/fullService/api/buildGiftCode.ts
@@ -48,7 +48,14 @@ const buildGiftCode = async ({
       valuePmob,
     }
   );
-  const { txProposal, giftCode, giftCodeB58 } = result as BuildGiftCodeResponse;
+
+  if (error) {
+    throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
+  }
+
+  const { txProposal, giftCode, giftCodeB58 } = result;
 
   // TODO fix type, right now it just matches what the component is expecting
   const totalValueConfirmation = txProposal.outlayList
@@ -57,18 +64,13 @@ const buildGiftCode = async ({
 
   const feeConfirmation = BigInt(txProposal.fee);
 
-  if (error) {
-    // TODO - I'll write up a better error handler
-    throw new Error(error);
-  } else {
-    return {
-      feeConfirmation,
-      giftCode,
-      giftCodeB58,
-      totalValueConfirmation,
-      txProposal,
-    };
-  }
+  return {
+    feeConfirmation,
+    giftCode,
+    giftCodeB58,
+    totalValueConfirmation,
+    txProposal,
+  };
 };
 
 export default buildGiftCode;

--- a/app/fullService/api/buildGiftCode.ts
+++ b/app/fullService/api/buildGiftCode.ts
@@ -1,7 +1,7 @@
 import type { GiftCode } from '../../types/GiftCode.d';
 import type { StringHex, StringB58, StringUInt64 } from '../../types/SpecialStrings.d';
 import type { TxProposal } from '../../types/TxProposal';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const BUILD_GIFT_CODE_METHOD = 'build_gift_code';
 
@@ -23,13 +23,10 @@ export type BuildGiftCodeResult = {
   txProposal: TxProposal;
 };
 
-type AxiosFullServiceResponse = {
-  error: string;
-  result: {
-    giftCode: GiftCode;
-    giftCodeB58: StringB58;
-    txProposal: TxProposal;
-  };
+type BuildGiftCodeResponse = {
+  giftCode: GiftCode;
+  giftCodeB58: StringB58;
+  txProposal: TxProposal;
 };
 
 const buildGiftCode = async ({
@@ -40,7 +37,7 @@ const buildGiftCode = async ({
   tombstoneBlock,
   valuePmob,
 }: BuildGiftCodeParams): Promise<BuildGiftCodeResult> => {
-  const { result, error }: AxiosFullServiceResponse = await axiosFullService(
+  const { result, error }: AxiosFullServiceResponse<BuildGiftCodeResponse> = await axiosFullService(
     BUILD_GIFT_CODE_METHOD,
     {
       accountId,
@@ -51,7 +48,7 @@ const buildGiftCode = async ({
       valuePmob,
     }
   );
-  const { txProposal, giftCode, giftCodeB58 } = result;
+  const { txProposal, giftCode, giftCodeB58 } = result as BuildGiftCodeResponse;
 
   // TODO fix type, right now it just matches what the component is expecting
   const totalValueConfirmation = txProposal.outlayList

--- a/app/fullService/api/buildTransaction.ts
+++ b/app/fullService/api/buildTransaction.ts
@@ -41,13 +41,14 @@ const buildTransaction = async ({
       tombstoneBlock,
       valuePmob,
     });
+
   if (error) {
     throw new Error(error);
-  } else if (typeof result === undefined) {
-    throw new Error('empty TxProposal response');
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   }
 
-  const { txProposal } = result as { txProposal: TxProposal };
+  const { txProposal } = result;
   // FIX-ME: assumes only 1 recipient
   const txProposalReceiverB58Code = recipientPublicAddress;
 

--- a/app/fullService/api/checkB58PaymentRequest.ts
+++ b/app/fullService/api/checkB58PaymentRequest.ts
@@ -34,6 +34,8 @@ const checkB58PaymentRequest = async (
 
   if (error || result?.b58Type !== 'PaymentRequest') {
     checkResponse.error = 'Invalid payment request code.';
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   }
 
   const validatedResult = result as CheckB58PaymentRequestResult;

--- a/app/fullService/api/checkB58PaymentRequest.ts
+++ b/app/fullService/api/checkB58PaymentRequest.ts
@@ -1,5 +1,5 @@
 import type { StringB58, StringUInt64 } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const CHECK_B58_TYPE_METHOD = 'check_b58_type';
 
@@ -7,23 +7,41 @@ export type CheckB58PaymentRequestParams = {
   b58Code: StringB58;
 };
 
+export type CheckB58PaymentRequestResponse = {
+  error?: string;
+  publicAddressB58?: StringB58;
+  value?: StringUInt64;
+};
+
 export type CheckB58PaymentRequestResult = {
-  type: string;
-  data: {
-    b58Code: StringB58;
-    valuePmob: StringUInt64;
-  };
+  b58Type: string;
+  data: CheckB58PaymentRequestData;
+};
+
+type CheckB58PaymentRequestData = {
+  value: StringUInt64;
+  publicAddressB58: StringB58;
+  memo: string;
 };
 
 const checkB58PaymentRequest = async (
   b58Code: CheckB58PaymentRequestParams
-): Promise<CheckB58PaymentRequestResult> => {
-  const res = await axiosFullService(CHECK_B58_TYPE_METHOD, { b58Code });
+): Promise<CheckB58PaymentRequestResponse> => {
+  const { result, error }: AxiosFullServiceResponse<CheckB58PaymentRequestResult> =
+    await axiosFullService(CHECK_B58_TYPE_METHOD, { b58Code });
 
-  if (res.error || res.result.b58Type !== 'PaymentRequest') {
-    return { error: 'Invalid payment request code.' };
+  const checkResponse: CheckB58PaymentRequestResponse = {};
+
+  if (error || result?.b58Type !== 'PaymentRequest') {
+    checkResponse.error = 'Invalid payment request code.';
   }
-  return res.result.data;
+
+  const validatedResult = result as CheckB58PaymentRequestResult;
+
+  checkResponse.publicAddressB58 = validatedResult.data.publicAddressB58;
+  checkResponse.value = validatedResult.data.value;
+
+  return checkResponse;
 };
 
 export default checkB58PaymentRequest;

--- a/app/fullService/api/checkGiftCodeStatus.ts
+++ b/app/fullService/api/checkGiftCodeStatus.ts
@@ -21,10 +21,11 @@ const checkGiftCodeStatus = async ({
     });
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as CheckGiftCodeStatusResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/checkGiftCodeStatus.ts
+++ b/app/fullService/api/checkGiftCodeStatus.ts
@@ -1,5 +1,5 @@
 import type { StringB58 } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const CHECK_GIFT_CODE_STATUS_METHOD = 'check_gift_code_status';
 
@@ -15,15 +15,16 @@ export type CheckGiftCodeStatusResult = {
 const checkGiftCodeStatus = async ({
   giftCodeB58,
 }: CheckGiftCodeStatusParams): Promise<CheckGiftCodeStatusResult> => {
-  const { result, error } = await axiosFullService(CHECK_GIFT_CODE_STATUS_METHOD, {
-    giftCodeB58,
-  });
+  const { result, error }: AxiosFullServiceResponse<CheckGiftCodeStatusResult> =
+    await axiosFullService(CHECK_GIFT_CODE_STATUS_METHOD, {
+      giftCodeB58,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as CheckGiftCodeStatusResult;
   }
 };
 

--- a/app/fullService/api/claimGiftCode.ts
+++ b/app/fullService/api/claimGiftCode.ts
@@ -1,5 +1,5 @@
 import type { StringB58, StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const CLAIM_GIFT_CODE_METHOD = 'claim_gift_code';
 
@@ -18,17 +18,20 @@ const claimGiftCode = async ({
   address,
   giftCodeB58,
 }: ClaimGiftCodeParams): Promise<ClaimGiftCodeResult> => {
-  const { result, error } = await axiosFullService(CLAIM_GIFT_CODE_METHOD, {
-    accountId,
-    address,
-    giftCodeB58,
-  });
+  const { result, error }: AxiosFullServiceResponse<ClaimGiftCodeResult> = await axiosFullService(
+    CLAIM_GIFT_CODE_METHOD,
+    {
+      accountId,
+      address,
+      giftCodeB58,
+    }
+  );
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as ClaimGiftCodeResult;
   }
 };
 

--- a/app/fullService/api/claimGiftCode.ts
+++ b/app/fullService/api/claimGiftCode.ts
@@ -28,10 +28,11 @@ const claimGiftCode = async ({
   );
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as ClaimGiftCodeResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/createAccount.ts
+++ b/app/fullService/api/createAccount.ts
@@ -1,5 +1,5 @@
 import type { Account } from '../../types/Account.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const CREATE_ACCOUNT_METHOD = 'create_account';
 
@@ -16,16 +16,19 @@ const createAccount = async ({
   firstBlockIndex,
   name,
 }: CreateAccountParams): Promise<CreateAccountResult> => {
-  const { result, error } = await axiosFullService(CREATE_ACCOUNT_METHOD, {
-    firstBlockIndex,
-    name,
-  });
+  const { result, error }: AxiosFullServiceResponse<CreateAccountResult> = await axiosFullService(
+    CREATE_ACCOUNT_METHOD,
+    {
+      firstBlockIndex,
+      name,
+    }
+  );
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as CreateAccountResult;
   }
 };
 

--- a/app/fullService/api/createAccount.ts
+++ b/app/fullService/api/createAccount.ts
@@ -25,10 +25,11 @@ const createAccount = async ({
   );
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as CreateAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/createReceiverReceipts.ts
+++ b/app/fullService/api/createReceiverReceipts.ts
@@ -19,11 +19,13 @@ const createReceiverReceipts = async ({
     await axiosFullService(CREATE_RECEIVER_RECEIPTS_METHOD, {
       txProposal,
     });
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as CreateReceiverReceiptsResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/createReceiverReceipts.ts
+++ b/app/fullService/api/createReceiverReceipts.ts
@@ -1,6 +1,6 @@
 import type { ReceiverReceipts } from '../../types/ReceiverReceipt';
 import type { TxProposal } from '../../types/TxProposal';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const CREATE_RECEIVER_RECEIPTS_METHOD = 'create_receiver_receipts';
 
@@ -15,14 +15,15 @@ type CreateReceiverReceiptsResult = {
 const createReceiverReceipts = async ({
   txProposal,
 }: CreateReceiverReceiptsParams): Promise<CreateReceiverReceiptsResult> => {
-  const { result, error } = await axiosFullService(CREATE_RECEIVER_RECEIPTS_METHOD, {
-    txProposal,
-  });
+  const { result, error }: AxiosFullServiceResponse<CreateReceiverReceiptsResult> =
+    await axiosFullService(CREATE_RECEIVER_RECEIPTS_METHOD, {
+      txProposal,
+    });
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as CreateReceiverReceiptsResult;
   }
 };
 

--- a/app/fullService/api/exportAccountSecrets.ts
+++ b/app/fullService/api/exportAccountSecrets.ts
@@ -21,10 +21,11 @@ const exportAccountSecrets = async ({
     });
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as ExportAccountSecretsResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/exportAccountSecrets.ts
+++ b/app/fullService/api/exportAccountSecrets.ts
@@ -1,6 +1,6 @@
 import type { AccountSecrets } from '../../types/AccountSecrets.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const EXPORT_ACCOUNT_SECRETS_METHOD = 'export_account_secrets';
 
@@ -15,15 +15,16 @@ type ExportAccountSecretsResult = {
 const exportAccountSecrets = async ({
   accountId,
 }: ExportAccountSecretsParams): Promise<ExportAccountSecretsResult> => {
-  const { result, error } = await axiosFullService(EXPORT_ACCOUNT_SECRETS_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<ExportAccountSecretsResult> =
+    await axiosFullService(EXPORT_ACCOUNT_SECRETS_METHOD, {
+      accountId,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as ExportAccountSecretsResult;
   }
 };
 

--- a/app/fullService/api/getAccount.ts
+++ b/app/fullService/api/getAccount.ts
@@ -1,6 +1,6 @@
 import type { Account } from '../../types/Account.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ACCOUNT_METHOD = 'get_account';
 
@@ -13,15 +13,18 @@ type GetAccountResult = {
 };
 
 const getAccount = async ({ accountId }: GetAccountParams): Promise<GetAccountResult> => {
-  const { result, error } = await axiosFullService(GET_ACCOUNT_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetAccountResult> = await axiosFullService(
+    GET_ACCOUNT_METHOD,
+    {
+      accountId,
+    }
+  );
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetAccountResult;
   }
 };
 

--- a/app/fullService/api/getAccount.ts
+++ b/app/fullService/api/getAccount.ts
@@ -21,10 +21,11 @@ const getAccount = async ({ accountId }: GetAccountParams): Promise<GetAccountRe
   );
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getAccountStatus.ts
+++ b/app/fullService/api/getAccountStatus.ts
@@ -21,10 +21,11 @@ const getAccountStatus = async ({
     });
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetAccountStatusResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getAccountStatus.ts
+++ b/app/fullService/api/getAccountStatus.ts
@@ -1,6 +1,6 @@
 import type { Account } from '../../types/Account.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ACCOUNT_STATUS_METHOD = 'get_account_status';
 
@@ -15,15 +15,16 @@ type GetAccountStatusResult = {
 const getAccountStatus = async ({
   accountId,
 }: GetAccountStatusParams): Promise<GetAccountStatusResult> => {
-  const { result, error } = await axiosFullService(GET_ACCOUNT_STATUS_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetAccountStatusResult> =
+    await axiosFullService(GET_ACCOUNT_STATUS_METHOD, {
+      accountId,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetAccountStatusResult;
   }
 };
 

--- a/app/fullService/api/getAllAccounts.ts
+++ b/app/fullService/api/getAllAccounts.ts
@@ -1,17 +1,19 @@
 import type { Accounts } from '../../types/Account.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ALL_ACCOUNTS_METHOD = 'get_all_accounts';
 
 type GetAllAccountsResult = Accounts;
 
 const getAllAccounts = async (): Promise<GetAllAccountsResult> => {
-  const { result, error } = await axiosFullService(GET_ALL_ACCOUNTS_METHOD);
+  const { result, error }: AxiosFullServiceResponse<GetAllAccountsResult> = await axiosFullService(
+    GET_ALL_ACCOUNTS_METHOD
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetAllAccountsResult;
   }
 };
 

--- a/app/fullService/api/getAllAccounts.ts
+++ b/app/fullService/api/getAllAccounts.ts
@@ -10,10 +10,11 @@ const getAllAccounts = async (): Promise<GetAllAccountsResult> => {
     GET_ALL_ACCOUNTS_METHOD
   );
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetAllAccountsResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getAllAddressesForAccount.ts
+++ b/app/fullService/api/getAllAddressesForAccount.ts
@@ -1,6 +1,6 @@
-import type { Addresses } from '../../types/Address.d';
+import type { Address, Addresses } from '../../types/Address.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ALL_ADRESSES_FOR_ACCOUNT_METHOD = 'get_all_addresses_for_account';
 
@@ -10,20 +10,26 @@ type GetAllAddressesForAccountParams = {
 
 type GetAllAddressesForAccountResult = Addresses;
 
+type GetAllAddressesForAccountResponse = {
+  publicAddresses: string[];
+  addressMap: { [addressId: string]: Address };
+};
+
 const getAllAddressesForAccount = async ({
   accountId,
 }: GetAllAddressesForAccountParams): Promise<GetAllAddressesForAccountResult> => {
-  const { result, error } = await axiosFullService(GET_ALL_ADRESSES_FOR_ACCOUNT_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetAllAddressesForAccountResponse> =
+    await axiosFullService(GET_ALL_ADRESSES_FOR_ACCOUNT_METHOD, {
+      accountId,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
     return {
-      addressIds: result.publicAddresses,
-      addressMap: result.addressMap,
+      addressIds: (result as GetAllAddressesForAccountResponse).publicAddresses,
+      addressMap: (result as GetAllAddressesForAccountResponse).addressMap,
     };
   }
 };

--- a/app/fullService/api/getAllAddressesForAccount.ts
+++ b/app/fullService/api/getAllAddressesForAccount.ts
@@ -24,8 +24,9 @@ const getAllAddressesForAccount = async ({
     });
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
     return {
       addressIds: (result as GetAllAddressesForAccountResponse).publicAddresses,

--- a/app/fullService/api/getAllGiftCodes.ts
+++ b/app/fullService/api/getAllGiftCodes.ts
@@ -1,5 +1,5 @@
 import type { GiftCode } from '../../types/GiftCode.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ALL_GIFT_CODES_METHOD = 'get_all_gift_codes';
 
@@ -8,12 +8,14 @@ type GetAllGiftCodesResult = {
 };
 
 const getAllGiftCodes = async (): Promise<GetAllGiftCodesResult> => {
-  const { result, error } = await axiosFullService(GET_ALL_GIFT_CODES_METHOD);
+  const { result, error }: AxiosFullServiceResponse<GetAllGiftCodesResult> = await axiosFullService(
+    GET_ALL_GIFT_CODES_METHOD
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetAllGiftCodesResult;
   }
 };
 

--- a/app/fullService/api/getAllGiftCodes.ts
+++ b/app/fullService/api/getAllGiftCodes.ts
@@ -12,10 +12,11 @@ const getAllGiftCodes = async (): Promise<GetAllGiftCodesResult> => {
     GET_ALL_GIFT_CODES_METHOD
   );
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetAllGiftCodesResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getAllTransactionLogsForAccount.ts
+++ b/app/fullService/api/getAllTransactionLogsForAccount.ts
@@ -1,6 +1,6 @@
 import type { StringHex } from '../../types/SpecialStrings.d';
 import type { TransactionLogs } from '../../types/TransactionLog.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ALL_TRANSACTION_LOGS_FOR_ACCOUNT_METHOD = 'get_all_transaction_logs_for_account';
 
@@ -14,14 +14,15 @@ type GetAllTransactionLogsForAccountResult = TransactionLogs;
 const getAllTransactionLogsForAccount = async ({
   accountId,
 }: GetAllTransactionLogsForAccountParams): Promise<GetAllTransactionLogsForAccountResult> => {
-  const { result, error } = await axiosFullService(GET_ALL_TRANSACTION_LOGS_FOR_ACCOUNT_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetAllTransactionLogsForAccountResult> =
+    await axiosFullService(GET_ALL_TRANSACTION_LOGS_FOR_ACCOUNT_METHOD, {
+      accountId,
+    });
   if (error) {
     // TODO - I'll write up a better error handler.
     throw new Error(error);
   } else {
-    return result;
+    return result as GetAllTransactionLogsForAccountResult;
   }
 };
 

--- a/app/fullService/api/getAllTransactionLogsForAccount.ts
+++ b/app/fullService/api/getAllTransactionLogsForAccount.ts
@@ -18,11 +18,13 @@ const getAllTransactionLogsForAccount = async ({
     await axiosFullService(GET_ALL_TRANSACTION_LOGS_FOR_ACCOUNT_METHOD, {
       accountId,
     });
+
   if (error) {
-    // TODO - I'll write up a better error handler.
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetAllTransactionLogsForAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getAllTransactionLogsForBlock.ts
+++ b/app/fullService/api/getAllTransactionLogsForBlock.ts
@@ -1,6 +1,6 @@
 import type { StringUInt64 } from '../../types/SpecialStrings.d';
 import type { TransactionLogs } from '../../types/TransactionLog.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ALL_TRANSACTION_LOGS_FOR_BLOCK_METHOD = 'get_all_transaction_logs_for_block';
 
@@ -14,14 +14,15 @@ type GetAllTransactionLogsForAccountResult = TransactionLogs;
 const getAllTransactionLogsForAccount = async ({
   blockIndex,
 }: GetAllTransactionLogsForAccountParams): Promise<GetAllTransactionLogsForAccountResult> => {
-  const { result, error } = await axiosFullService(GET_ALL_TRANSACTION_LOGS_FOR_BLOCK_METHOD, {
-    blockIndex,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetAllTransactionLogsForAccountResult> =
+    await axiosFullService(GET_ALL_TRANSACTION_LOGS_FOR_BLOCK_METHOD, {
+      blockIndex,
+    });
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetAllTransactionLogsForAccountResult;
   }
 };
 

--- a/app/fullService/api/getAllTransactionLogsForBlock.ts
+++ b/app/fullService/api/getAllTransactionLogsForBlock.ts
@@ -18,11 +18,13 @@ const getAllTransactionLogsForAccount = async ({
     await axiosFullService(GET_ALL_TRANSACTION_LOGS_FOR_BLOCK_METHOD, {
       blockIndex,
     });
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetAllTransactionLogsForAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getAllTxosForAccount.ts
+++ b/app/fullService/api/getAllTxosForAccount.ts
@@ -1,6 +1,6 @@
 import type { StringHex } from '../../types/SpecialStrings.d';
 import type { Txos } from '../../types/Txo.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_ALL_TXOS_FOR_ACCOUNT_METHOD = 'get_all_txos_for_account';
 
@@ -13,15 +13,16 @@ type GetAllTxosByAccountResult = Txos;
 const getAllTxosForAccount = async ({
   accountId,
 }: GetAllTxosByAccountParams): Promise<GetAllTxosByAccountResult> => {
-  const { result, error } = await axiosFullService(GET_ALL_TXOS_FOR_ACCOUNT_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetAllTxosByAccountResult> =
+    await axiosFullService(GET_ALL_TXOS_FOR_ACCOUNT_METHOD, {
+      accountId,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetAllTxosByAccountResult;
   }
 };
 

--- a/app/fullService/api/getAllTxosForAccount.ts
+++ b/app/fullService/api/getAllTxosForAccount.ts
@@ -19,10 +19,11 @@ const getAllTxosForAccount = async ({
     });
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetAllTxosByAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getBalanceForAccount.ts
+++ b/app/fullService/api/getBalanceForAccount.ts
@@ -19,11 +19,13 @@ const getBalance = async ({ accountId }: GetBalanceParams): Promise<GetBalanceRe
       accountId,
     }
   );
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetBalanceResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getBalanceForAccount.ts
+++ b/app/fullService/api/getBalanceForAccount.ts
@@ -1,6 +1,6 @@
 import type { BalanceStatus } from '../../types/BalanceStatus.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_BALANCE_FOR_ACCOUNT_METHOD = 'get_balance_for_account';
 
@@ -13,14 +13,17 @@ type GetBalanceResult = {
 };
 
 const getBalance = async ({ accountId }: GetBalanceParams): Promise<GetBalanceResult> => {
-  const { result, error } = await axiosFullService(GET_BALANCE_FOR_ACCOUNT_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetBalanceResult> = await axiosFullService(
+    GET_BALANCE_FOR_ACCOUNT_METHOD,
+    {
+      accountId,
+    }
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetBalanceResult;
   }
 };
 

--- a/app/fullService/api/getBalanceForAddress.ts
+++ b/app/fullService/api/getBalanceForAddress.ts
@@ -19,11 +19,13 @@ const getBalance = async ({ accountId }: GetBalanceParams): Promise<GetBalanceRe
       accountId,
     }
   );
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetBalanceResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getBalanceForAddress.ts
+++ b/app/fullService/api/getBalanceForAddress.ts
@@ -1,6 +1,6 @@
 import type { BalanceStatus } from '../../types/BalanceStatus.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_BALANCE_FOR_ADDRESS_METHOD = 'get_balance_for_address';
 
@@ -13,14 +13,17 @@ type GetBalanceResult = {
 };
 
 const getBalance = async ({ accountId }: GetBalanceParams): Promise<GetBalanceResult> => {
-  const { result, error } = await axiosFullService(GET_BALANCE_FOR_ADDRESS_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetBalanceResult> = await axiosFullService(
+    GET_BALANCE_FOR_ADDRESS_METHOD,
+    {
+      accountId,
+    }
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetBalanceResult;
   }
 };
 

--- a/app/fullService/api/getConfirmations.ts
+++ b/app/fullService/api/getConfirmations.ts
@@ -19,11 +19,13 @@ const getConfirmations = async ({
     await axiosFullService(GET_CONFIRMATIONS_METHOD, {
       transactionLogId,
     });
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetConfirmationsResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getConfirmations.ts
+++ b/app/fullService/api/getConfirmations.ts
@@ -1,6 +1,6 @@
 import { Confirmations } from '../../types/Confirmation';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_CONFIRMATIONS_METHOD = 'get_confirmations';
 
@@ -15,14 +15,15 @@ type GetConfirmationsResult = {
 const getConfirmations = async ({
   transactionLogId,
 }: GetConfirmationsParams): Promise<GetConfirmationsResult> => {
-  const { result, error } = await axiosFullService(GET_CONFIRMATIONS_METHOD, {
-    transactionLogId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetConfirmationsResult> =
+    await axiosFullService(GET_CONFIRMATIONS_METHOD, {
+      transactionLogId,
+    });
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetConfirmationsResult;
   }
 };
 

--- a/app/fullService/api/getGiftCode.ts
+++ b/app/fullService/api/getGiftCode.ts
@@ -1,6 +1,6 @@
 import type { GiftCode } from '../../types/GiftCode.d';
 import type { StringB58 } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_GIFT_CODE_METHOD = 'get_gift_code';
 
@@ -13,14 +13,17 @@ type GetGiftCodeResult = {
 };
 
 const getGiftCode = async ({ giftCodeB58 }: GetGiftCodeParams): Promise<GetGiftCodeResult> => {
-  const { result, error } = await axiosFullService(GET_GIFT_CODE_METHOD, {
-    giftCodeB58,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetGiftCodeResult> = await axiosFullService(
+    GET_GIFT_CODE_METHOD,
+    {
+      giftCodeB58,
+    }
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetGiftCodeResult;
   }
 };
 

--- a/app/fullService/api/getGiftCode.ts
+++ b/app/fullService/api/getGiftCode.ts
@@ -19,11 +19,13 @@ const getGiftCode = async ({ giftCodeB58 }: GetGiftCodeParams): Promise<GetGiftC
       giftCodeB58,
     }
   );
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetGiftCodeResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getNetworkStatus.ts
+++ b/app/fullService/api/getNetworkStatus.ts
@@ -1,5 +1,5 @@
 import type { NetworkStatus } from '../../types/NetworkStatus.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_NETWORK_STATUS_METHOD = 'get_network_status';
 
@@ -8,11 +8,12 @@ type GetNetworkStatusResult = {
 };
 
 const getNetworkStatus = async (): Promise<GetNetworkStatusResult> => {
-  const { result, error } = await axiosFullService(GET_NETWORK_STATUS_METHOD);
+  const { result, error }: AxiosFullServiceResponse<GetNetworkStatusResult> =
+    await axiosFullService(GET_NETWORK_STATUS_METHOD);
   if (error) {
     throw new Error(error);
   } else {
-    return result;
+    return result as GetNetworkStatusResult;
   }
 };
 

--- a/app/fullService/api/getNetworkStatus.ts
+++ b/app/fullService/api/getNetworkStatus.ts
@@ -10,10 +10,13 @@ type GetNetworkStatusResult = {
 const getNetworkStatus = async (): Promise<GetNetworkStatusResult> => {
   const { result, error }: AxiosFullServiceResponse<GetNetworkStatusResult> =
     await axiosFullService(GET_NETWORK_STATUS_METHOD);
+
   if (error) {
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetNetworkStatusResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getTransactionLog.ts
+++ b/app/fullService/api/getTransactionLog.ts
@@ -21,10 +21,11 @@ const getTransactionLog = async ({
     });
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetTransactionLogResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getTransactionLog.ts
+++ b/app/fullService/api/getTransactionLog.ts
@@ -1,6 +1,6 @@
 import type { StringHex } from '../../types/SpecialStrings.d';
 import type { TransactionLog } from '../../types/TransactionLog.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_TRANSACTION_LOG_METHOD = 'get_transaction_LOG';
 
@@ -15,15 +15,16 @@ type GetTransactionLogResult = {
 const getTransactionLog = async ({
   transactionLogId,
 }: GetTransactionLogParams): Promise<GetTransactionLogResult> => {
-  const { result, error } = await axiosFullService(GET_TRANSACTION_LOG_METHOD, {
-    transactionLogId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetTransactionLogResult> =
+    await axiosFullService(GET_TRANSACTION_LOG_METHOD, {
+      transactionLogId,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetTransactionLogResult;
   }
 };
 

--- a/app/fullService/api/getTxo.ts
+++ b/app/fullService/api/getTxo.ts
@@ -1,6 +1,6 @@
 import type { StringHex } from '../../types/SpecialStrings.d';
 import type { Txo } from '../../types/Txo.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_TXO_METHOD = 'get_txo';
 
@@ -13,15 +13,18 @@ type GetTxoResult = {
 };
 
 const getTxo = async ({ txoId }: GetTxoParams): Promise<GetTxoResult> => {
-  const { result, error } = await axiosFullService(GET_TXO_METHOD, {
-    txoId,
-  });
+  const { result, error }: AxiosFullServiceResponse<GetTxoResult> = await axiosFullService(
+    GET_TXO_METHOD,
+    {
+      txoId,
+    }
+  );
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetTxoResult;
   }
 };
 

--- a/app/fullService/api/getTxo.ts
+++ b/app/fullService/api/getTxo.ts
@@ -21,10 +21,11 @@ const getTxo = async ({ txoId }: GetTxoParams): Promise<GetTxoResult> => {
   );
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetTxoResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getWalletStatus.ts
+++ b/app/fullService/api/getWalletStatus.ts
@@ -11,11 +11,13 @@ const getWalletStatus = async (): Promise<GetWalletStatusResult> => {
   const { result, error }: AxiosFullServiceResponse<GetWalletStatusResult> = await axiosFullService(
     GET_WALLET_STATUS_METHOD
   );
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as GetWalletStatusResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/getWalletStatus.ts
+++ b/app/fullService/api/getWalletStatus.ts
@@ -1,5 +1,5 @@
 import type { WalletStatus } from '../../types/WalletStatus.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_WALLET_STATUS_METHOD = 'get_wallet_status';
 
@@ -8,12 +8,14 @@ type GetWalletStatusResult = {
 };
 
 const getWalletStatus = async (): Promise<GetWalletStatusResult> => {
-  const { result, error } = await axiosFullService(GET_WALLET_STATUS_METHOD);
+  const { result, error }: AxiosFullServiceResponse<GetWalletStatusResult> = await axiosFullService(
+    GET_WALLET_STATUS_METHOD
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as GetWalletStatusResult;
   }
 };
 

--- a/app/fullService/api/importAccount.ts
+++ b/app/fullService/api/importAccount.ts
@@ -1,5 +1,5 @@
 import type { Account } from '../../types/Account.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const IMPORT_ACCOUNT_METHOD = 'import_account';
 
@@ -20,18 +20,21 @@ const importAccount = async ({
   firstBlockIndex,
   name,
 }: ImportAccountParams): Promise<ImportAccountResult> => {
-  const { result, error } = await axiosFullService(IMPORT_ACCOUNT_METHOD, {
-    firstBlockIndex,
-    key_derivation_version,
-    mnemonic,
-    name,
-  });
+  const { result, error }: AxiosFullServiceResponse<ImportAccountResult> = await axiosFullService(
+    IMPORT_ACCOUNT_METHOD,
+    {
+      firstBlockIndex,
+      key_derivation_version,
+      mnemonic,
+      name,
+    }
+  );
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as ImportAccountResult;
   }
 };
 

--- a/app/fullService/api/importAccount.ts
+++ b/app/fullService/api/importAccount.ts
@@ -31,10 +31,11 @@ const importAccount = async ({
   );
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as ImportAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/importLegacyAccount.ts
+++ b/app/fullService/api/importLegacyAccount.ts
@@ -1,5 +1,5 @@
 import type { Account } from '../../types/Account.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const IMPORT_LEGACY_ACCOUNT_METHOD = 'import_account_from_legacy_root_entropy';
 
@@ -18,17 +18,20 @@ const importLegacyAccount = async ({
   firstBlockIndex,
   name,
 }: ImportAccountParams): Promise<ImportAccountResult> => {
-  const { result, error } = await axiosFullService(IMPORT_LEGACY_ACCOUNT_METHOD, {
-    entropy,
-    firstBlockIndex,
-    name,
-  });
+  const { result, error }: AxiosFullServiceResponse<ImportAccountResult> = await axiosFullService(
+    IMPORT_LEGACY_ACCOUNT_METHOD,
+    {
+      entropy,
+      firstBlockIndex,
+      name,
+    }
+  );
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as ImportAccountResult;
   }
 };
 

--- a/app/fullService/api/importLegacyAccount.ts
+++ b/app/fullService/api/importLegacyAccount.ts
@@ -28,10 +28,11 @@ const importLegacyAccount = async ({
   );
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as ImportAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/removeAccount.ts
+++ b/app/fullService/api/removeAccount.ts
@@ -1,5 +1,5 @@
 import { removeKeychainAccounts } from '../../utils/keytarService';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const REMOVE_ACCOUNT_METHOD = 'remove_account';
 
@@ -12,15 +12,18 @@ export type RemoveAccountResult = {
 };
 
 const removeAccount = async ({ accountId }: RemoveAccountParams): Promise<RemoveAccountResult> => {
-  const { result, error } = await axiosFullService(REMOVE_ACCOUNT_METHOD, {
-    accountId,
-  });
+  const { result, error }: AxiosFullServiceResponse<RemoveAccountResult> = await axiosFullService(
+    REMOVE_ACCOUNT_METHOD,
+    {
+      accountId,
+    }
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
     removeKeychainAccounts();
-    return result;
+    return result as RemoveAccountResult;
   }
 };
 

--- a/app/fullService/api/removeAccount.ts
+++ b/app/fullService/api/removeAccount.ts
@@ -18,12 +18,14 @@ const removeAccount = async ({ accountId }: RemoveAccountParams): Promise<Remove
       accountId,
     }
   );
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
     removeKeychainAccounts();
-    return result as RemoveAccountResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/removeGiftCode.ts
+++ b/app/fullService/api/removeGiftCode.ts
@@ -21,11 +21,13 @@ const removeGiftCode = async ({
       giftCodeB58,
     }
   );
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as RemoveGiftCodeResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/removeGiftCode.ts
+++ b/app/fullService/api/removeGiftCode.ts
@@ -1,6 +1,6 @@
 import type { GiftCode } from '../../types/GiftCode.d';
 import type { StringB58 } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const REMOVE_GIFT_CODE_METHOD = 'remove_gift_code';
 
@@ -15,14 +15,17 @@ export type RemoveGiftCodeResult = {
 const removeGiftCode = async ({
   giftCodeB58,
 }: RemoveGiftCodeParams): Promise<RemoveGiftCodeResult> => {
-  const { result, error } = await axiosFullService(REMOVE_GIFT_CODE_METHOD, {
-    giftCodeB58,
-  });
+  const { result, error }: AxiosFullServiceResponse<RemoveGiftCodeResult> = await axiosFullService(
+    REMOVE_GIFT_CODE_METHOD,
+    {
+      giftCodeB58,
+    }
+  );
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as RemoveGiftCodeResult;
   }
 };
 

--- a/app/fullService/api/submitGiftCode.ts
+++ b/app/fullService/api/submitGiftCode.ts
@@ -1,7 +1,7 @@
 import type { GiftCode } from '../../types/GiftCode.d';
 import type { StringHex, StringB58 } from '../../types/SpecialStrings.d';
 import type { TxProposal } from '../../types/TxProposal.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const SUBMIT_GIFT_CODE_METHOD = 'submit_gift_code';
 
@@ -15,19 +15,12 @@ export type SubmitGiftCodeResult = {
   giftCode: GiftCode;
 };
 
-type AxiosFullServiceResponse = {
-  error: string;
-  result: {
-    giftCode: GiftCode;
-  };
-};
-
 const submitGiftCode = async ({
   fromAccountId,
   giftCodeB58,
   txProposal,
 }: SubmitGiftCodeParams): Promise<SubmitGiftCodeResult> => {
-  const { result, error }: AxiosFullServiceResponse = await axiosFullService(
+  const { result, error }: AxiosFullServiceResponse<SubmitGiftCodeResult> = await axiosFullService(
     SUBMIT_GIFT_CODE_METHOD,
     {
       fromAccountId,
@@ -36,7 +29,7 @@ const submitGiftCode = async ({
     }
   );
 
-  const { giftCode } = result;
+  const { giftCode } = result as SubmitGiftCodeResult;
 
   if (error) {
     // TODO - I'll write up a better error handler

--- a/app/fullService/api/submitGiftCode.ts
+++ b/app/fullService/api/submitGiftCode.ts
@@ -29,15 +29,12 @@ const submitGiftCode = async ({
     }
   );
 
-  const { giftCode } = result as SubmitGiftCodeResult;
-
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return {
-      giftCode,
-    };
+    return { giftCode: result.giftCode };
   }
 };
 

--- a/app/fullService/api/submitTransaction.ts
+++ b/app/fullService/api/submitTransaction.ts
@@ -1,7 +1,7 @@
 import type { StringHex } from '../../types/SpecialStrings.d';
 import type { TransactionLog } from '../../types/TransactionLog.d';
 import type { TxProposal } from '../../types/TxProposal.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const SUBMIT_TRANSACTION_METHOD = 'submit_transaction';
 
@@ -18,15 +18,16 @@ const submitTransaction = async ({
   accountId,
   txProposal,
 }: SubmitTransactionParams): Promise<SubmitTransactionResult> => {
-  const { result, error } = await axiosFullService(SUBMIT_TRANSACTION_METHOD, {
-    accountId,
-    txProposal,
-  });
+  const { result, error }: AxiosFullServiceResponse<SubmitTransactionResult> =
+    await axiosFullService(SUBMIT_TRANSACTION_METHOD, {
+      accountId,
+      txProposal,
+    });
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as SubmitTransactionResult;
   }
 };
 

--- a/app/fullService/api/submitTransaction.ts
+++ b/app/fullService/api/submitTransaction.ts
@@ -23,11 +23,13 @@ const submitTransaction = async ({
       accountId,
       txProposal,
     });
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as SubmitTransactionResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/updateAccountName.ts
+++ b/app/fullService/api/updateAccountName.ts
@@ -1,6 +1,6 @@
 import type { Account } from '../../types/Account.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const UPDATE_ACCOUNT_NAME = 'update_account_name';
 
@@ -17,16 +17,17 @@ const updateAccountName = async ({
   accountId,
   name,
 }: UpdateAccountNameParams): Promise<UpdateAccountNameResult> => {
-  const { result, error } = await axiosFullService(UPDATE_ACCOUNT_NAME, {
-    accountId,
-    name,
-  });
+  const { result, error }: AxiosFullServiceResponse<UpdateAccountNameResult> =
+    await axiosFullService(UPDATE_ACCOUNT_NAME, {
+      accountId,
+      name,
+    });
 
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as UpdateAccountNameResult;
   }
 };
 

--- a/app/fullService/api/updateAccountName.ts
+++ b/app/fullService/api/updateAccountName.ts
@@ -24,10 +24,11 @@ const updateAccountName = async ({
     });
 
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as UpdateAccountNameResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/validateConfirmation.ts
+++ b/app/fullService/api/validateConfirmation.ts
@@ -24,11 +24,13 @@ const validateConfirmation = async ({
       confirmation,
       txoId,
     });
+
   if (error) {
-    // TODO - I'll write up a better error handler
     throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
   } else {
-    return result as ValidateConfirmationResult;
+    return result;
   }
 };
 

--- a/app/fullService/api/validateConfirmation.ts
+++ b/app/fullService/api/validateConfirmation.ts
@@ -1,5 +1,5 @@
 import type { StringHex } from '../../types/SpecialStrings.d';
-import axiosFullService from '../axiosFullService';
+import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const VALIDATE_CONFIRMATION_METHOD = 'validate_confirmation';
 
@@ -18,16 +18,17 @@ const validateConfirmation = async ({
   confirmation,
   txoId,
 }: ValidateConfirmationParams): Promise<ValidateConfirmationResult> => {
-  const { result, error } = await axiosFullService(VALIDATE_CONFIRMATION_METHOD, {
-    accountId,
-    confirmation,
-    txoId,
-  });
+  const { result, error }: AxiosFullServiceResponse<ValidateConfirmationResult> =
+    await axiosFullService(VALIDATE_CONFIRMATION_METHOD, {
+      accountId,
+      confirmation,
+      txoId,
+    });
   if (error) {
     // TODO - I'll write up a better error handler
     throw new Error(error);
   } else {
-    return result;
+    return result as ValidateConfirmationResult;
   }
 };
 

--- a/app/fullService/axiosFullService.ts
+++ b/app/fullService/axiosFullService.ts
@@ -26,6 +26,8 @@ export const handleError = (error: { message?: string }) =>
   // Usually, bad urls (404) or incorrect methods (422).
   Promise.reject(error.message || 'Unknown Full-Service error');
 
+// TODO: refactor to include better error handling. Returning an optional error param offloads error
+// handling to the caller, breaking DRY
 const axiosFullService = async <T>(
   method: string,
   params?: Record<string, any>

--- a/app/fullService/axiosFullService.ts
+++ b/app/fullService/axiosFullService.ts
@@ -4,19 +4,19 @@ import snakeCaseKeys from 'snakecase-keys';
 
 import { skipKeysCamelCase } from './utils';
 
-interface FullServiceResponse extends AxiosResponse {
+type FullServiceResponse = AxiosResponse & {
   data: {
     method: string;
     jsonrpc: string;
     result?: any; // TODO, consider replacing with generic T
     error?: string;
   };
-}
+};
 
-interface AxiosFullServiceResponse {
-  result?: any; // TODO, consider replacing with generic T
+export type AxiosFullServiceResponse<T> = {
+  result?: T;
   error?: string;
-}
+};
 
 export const handleResponse = (response: AxiosResponse<FullServiceResponse>): FullServiceResponse =>
   response.data;
@@ -26,10 +26,10 @@ export const handleError = (error: { message?: string }) =>
   // Usually, bad urls (404) or incorrect methods (422).
   Promise.reject(error.message || 'Unknown Full-Service error');
 
-const axiosFullService = async (
+const axiosFullService = async <T>(
   method: string,
   params?: Record<string, any>
-): Promise<AxiosFullServiceResponse> => {
+): Promise<AxiosFullServiceResponse<T>> => {
   const axiosInstance = axios.create({
     baseURL: 'http://localhost:9090/wallet',
     headers: { 'Content-type': 'application/json' },
@@ -61,7 +61,7 @@ const axiosFullService = async (
   } catch (error) {
     // TODO: when we hit an unknown error, I think we can assume this application needs to restart
     // So, we should figure out a bug report path and a reset button.
-    const errorMessage = error.message || 'Unknown Rocket error';
+    const errorMessage = (error as Error).message || 'Unknown Rocket error';
     return { error: errorMessage };
   }
 };

--- a/app/pages/SendReceive/PaymentRequests.view/PaymentRequest.view.tsx
+++ b/app/pages/SendReceive/PaymentRequests.view/PaymentRequest.view.tsx
@@ -24,6 +24,7 @@ import { LongCode } from '../../../components/LongCode';
 import { checkB58PaymentRequest } from '../../../services/checkB58PaymentRequest.service';
 import type { Theme } from '../../../theme';
 import type { Account } from '../../../types/Account';
+import type { StringB58 } from '../../../types/SpecialStrings.d';
 import { PaymentRequestProps } from './PaymentRequest.d';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -80,9 +81,9 @@ const PaymentRequest: FC<PaymentRequestProps> = ({
 
   const handleCancel = onClickCancel;
 
-  const handleViewPaymentRequest = async (b58code) => {
+  const handleViewPaymentRequest = async (b58Code: StringB58) => {
     try {
-      const result = await checkB58PaymentRequest(b58code);
+      const result = await checkB58PaymentRequest({ b58Code });
       if (result.error) {
         throw new Error(result.error);
       }

--- a/app/services/checkB58PaymentRequest.service.ts
+++ b/app/services/checkB58PaymentRequest.service.ts
@@ -1,12 +1,12 @@
 import * as fullServiceApi from '../fullService/api';
 import type {
   CheckB58PaymentRequestParams,
-  CheckB58PaymentRequestResult,
+  CheckB58PaymentRequestResponse,
 } from '../fullService/api/checkB58PaymentRequest';
 
 const checkB58PaymentRequest = async (
   checkB58PaymentRequestParams: CheckB58PaymentRequestParams
-): Promise<CheckB58PaymentRequestResult> =>
+): Promise<CheckB58PaymentRequestResponse> =>
   fullServiceApi.checkB58PaymentRequest(checkB58PaymentRequestParams);
 
 export default checkB58PaymentRequest;


### PR DESCRIPTION
### Motivation

A user posted [an issue around error handling](https://github.com/mobilecoinofficial/desktop-wallet/issues/217). This was caused by us attempting to access the field `details` off of a `string` object, which was understandably failing.

Additionally, there were a lot of places where types were not defined, or improperly defined, which was causing a lot of TypeScript errors.

### In this PR

* Fix type and references to the `error` being thrown by the `buildTransaction` method.
* Add type generics to the `axiosFullService` method.
* Switch interface declarations for type declarations (in modern TypeScript, `type`s contain a superset of `interface`'s functionality, and we should be using `type` declarations wherever possible for consistency.)
