### PR TITLE
render or hide entropy text, not classes

### DIFF
--- a/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.view.tsx
+++ b/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.view.tsx
@@ -20,9 +20,6 @@ import type { Theme } from '../../../theme';
 import { ShowEntropyModalProps } from './ShowEntropyModal';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  hiddenEntropy: {
-    color: theme.palette.background.paper,
-  },
   modal: {
     alignItems: 'center',
     display: 'flex',
@@ -38,7 +35,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: theme.spacing(2, 4, 3),
   },
   root: {},
-  shownEntropy: {},
 }));
 
 const ShowEntropyModal: FC<ShowEntropyModalProps> = ({
@@ -108,12 +104,8 @@ const ShowEntropyModal: FC<ShowEntropyModalProps> = ({
                     </Fab>
                   </Box>
                   <Container maxWidth="sm">
-                    <Typography
-                      className={showEntropy ? classes.shownEntropy : classes.hiddenEntropy}
-                      variant="body2"
-                      color="textPrimary"
-                    >
-                      {mnemonic}
+                    <Typography variant="body2" color="textPrimary">
+                      <div style={{ minHeight: 60 }}>{showEntropy ? mnemonic : ''}</div>
                     </Typography>
                   </Container>
                 </Box>


### PR DESCRIPTION
### Motivation

When users have been hiding or showing their account's mnemonic, we've just been changing the color of the text, rather than actually changing whether or not we render the text. Technically theres a concern about screen-readers/scrapers being able to grab the text from the screen, but mostly its an antipattern thats straightforward to fix.

### In this PR

Rather than changing the color of the text between the text's default color and the color of the background, this change affects whether the mnemonic text gets rendered or not. 

To preserve the visual functionality of the application, I've set the minimum height of the container to be the normal height of the mnemonic phrase. In cases where the user is viewing the application on a very narrow screen, the box will stretch vertically to accommodate the text from the phrase.

FIxes issue number https://app.asana.com/0/1200242791884109/1200796953343249/f

### Screen Shots

Hidden
<img width="963" alt="Screen Shot 2022-02-25 at 5 46 37 PM" src="https://user-images.githubusercontent.com/45008070/155813240-f524e9aa-b821-46e2-a9b7-8c0eb98c481c.png">
Shown
<img width="963" alt="Screen Shot 2022-02-25 at 5 47 20 PM" src="https://user-images.githubusercontent.com/45008070/155813296-1af5ed34-928f-4b9a-8ee7-e5b2e8bd4e3b.png">


