### PR TITLE
Render about menu

### DIFF
--- a/app/menus/otherMenu.js
+++ b/app/menus/otherMenu.js
@@ -9,7 +9,7 @@ const openAboutWindow = async (mainWindow) => {
     height: 150,
     modal: true,
     parent: mainWindow,
-    title: '',
+    title: __dirname,
     webPreferences: {
       contextIsolation: true,
       disableBlinkFeatures: 'Auxclick',
@@ -18,11 +18,14 @@ const openAboutWindow = async (mainWindow) => {
     width: 300,
   });
 
-  await modal.loadFile('../app/menus/otherHelp.html', {
+  // await modal.loadFile('../../app/menus/otherHelp.html');
+  await modal.loadFile('app/menus/otherHelp.html', {
     query: { version: process.env.npm_package_version },
   });
   return modal;
 };
+
+// /tmp/.mount_MobileKZdlrL/resources/app.asar
 
 const defaultTemplate = (app, mainWindow, i18n) => {
   const submenuAbout = {

--- a/app/menus/otherMenu.js
+++ b/app/menus/otherMenu.js
@@ -1,15 +1,16 @@
 import { shell, nativeTheme, BrowserWindow } from 'electron';
 
 import config from '../../configs/app.config';
+import { version } from '../../package.json';
 import * as localStore from '../utils/LocalStore';
 
-const openAboutWindow = async (mainWindow) => {
+const openAboutWindow = async (mainWindow, i18n) => {
   const modal = new BrowserWindow({
     autoHideMenuBar: true,
     height: 150,
     modal: true,
     parent: mainWindow,
-    title: __dirname,
+    title: i18n.t('Menu.about'),
     webPreferences: {
       contextIsolation: true,
       disableBlinkFeatures: 'Auxclick',
@@ -18,21 +19,18 @@ const openAboutWindow = async (mainWindow) => {
     width: 300,
   });
 
-  // await modal.loadFile('../../app/menus/otherHelp.html');
-  await modal.loadFile('app/menus/otherHelp.html', {
-    query: { version: process.env.npm_package_version },
+  await modal.loadFile('../../app/menus/otherHelp.html', {
+    query: { version },
   });
   return modal;
 };
-
-// /tmp/.mount_MobileKZdlrL/resources/app.asar
 
 const defaultTemplate = (app, mainWindow, i18n) => {
   const submenuAbout = {
     label: i18n.t('Menu.mobileCoin'),
     submenu: [
       {
-        click: () => openAboutWindow(mainWindow),
+        click: () => openAboutWindow(mainWindow, i18n),
         label: i18n.t('Menu.about'),
         selector: 'orderFrontStandardAboutPanel:',
       },

--- a/package.json
+++ b/package.json
@@ -300,7 +300,6 @@
     "@hot-loader/react-dom": "^17.0.1",
     "@material-ui/core": "^4.12.1",
     "@material-ui/icons": "^4.11.2",
-    "asar": "^3.1.0",
     "axios": "^0.24.0",
     "bip39": "^3.0.4",
     "camelcase-keys": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,13 @@
       {
         "from": "locales",
         "to": "locales"
+      },
+      {
+        "from": "app",
+        "to": "app",
+        "filter": [
+          "menus/otherHelp.html"
+        ]
       }
     ],
     "dmg": {
@@ -293,6 +300,7 @@
     "@hot-loader/react-dom": "^17.0.1",
     "@material-ui/core": "^4.12.1",
     "@material-ui/icons": "^4.11.2",
+    "asar": "^3.1.0",
     "axios": "^0.24.0",
     "bip39": "^3.0.4",
     "camelcase-keys": "^7.0.0",


### PR DESCRIPTION
### Motivation

Desktop Wallet's 'About' menu is showing an empty screen in the Linux build.

### In this PR

Addresses the concern raised here: https://github.com/mobilecoinofficial/desktop-wallet/issues/189
Addresses ticket: https://app.asana.com/0/1200242791884109/1201766284070067/f

Two main issues were at play here. 
1. In the linux packaging, we lost the ability to explicitly reference the html content for the about menu. To solve this issue, I've added the content for this menu to be packaged as as separate file, rather than as part of the minified main app that electron runs in its rendering view.
2. In the packaged linux application, `process.env.npm_package_version` is undefined, which caused the About menu to show the default version instead of the up to date version. To solve this issue, `otherMenu.js` now imports the version directly from the `package.json` file, which the conceptual source of truth for the app version.

### Screen Shots

![desktop-wallet-about](https://user-images.githubusercontent.com/45008070/157104537-77fc7f33-b9da-432d-8779-40dc31bb805f.png)

