### PR TITLE
Fix broken fullServiceApi method: getBalanceForAddress({ address }), not {accountId}

### DIFF
--- a/app/fullService/api/getBalanceForAddress.ts
+++ b/app/fullService/api/getBalanceForAddress.ts
@@ -1,22 +1,22 @@
 import type { BalanceStatus } from '../../types/BalanceStatus.d';
-import type { StringHex } from '../../types/SpecialStrings.d';
+import type { StringB58 } from '../../types/SpecialStrings.d';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
 const GET_BALANCE_FOR_ADDRESS_METHOD = 'get_balance_for_address';
 
 type GetBalanceParams = {
-  accountId: StringHex;
+  address: StringB58;
 };
 
 type GetBalanceResult = {
   balance: BalanceStatus; // TODO - lock in name of object
 };
 
-const getBalance = async ({ accountId }: GetBalanceParams): Promise<GetBalanceResult> => {
+const getBalance = async ({ address }: GetBalanceParams): Promise<GetBalanceResult> => {
   const { result, error }: AxiosFullServiceResponse<GetBalanceResult> = await axiosFullService(
     GET_BALANCE_FOR_ADDRESS_METHOD,
     {
-      accountId,
+      address,
     }
   );
 


### PR DESCRIPTION
### Motivation

The wrapper for fullService's getBalanceForAddress() was wrong, incorrectly expecting an `{ accountId }` param, instead of `{ address }`.

See https://mobilecoin.gitbook.io/full-service-api/api-endpoints/account/balance/get_balance_for_address for another reference.

### In this PR

The call signature is fixed.

### Caveats

- Quickly searching through the repo, its not clear this `getBalanceForAddress()` function is actually being used, explaining why this error wasn't noticed sooner. 
  - Another course of action would be to outright delete the file since it's unused.
  - Counter to that is that it still served me as a useful reference to see how to call fullService from JS/TS.

### Screen Shots

#### Before (error)

<img width="706" alt="image" src="https://user-images.githubusercontent.com/6340841/172025428-39188be2-d0bb-408f-9ba1-920807871a83.png">

#### After (fixed!)

<img width="280" alt="image" src="https://user-images.githubusercontent.com/6340841/172025453-46dc8bf1-aad5-4c86-aff3-3a3b83edee55.png">

