### PR TITLE
Fix typo: 'tx_status_succeded'

### DIFF
--- a/app/types/TransactionLog.d.ts
+++ b/app/types/TransactionLog.d.ts
@@ -32,7 +32,7 @@ export interface TransactionLog {
     | 'tx_status_built'
     | 'tx_status_pending'
     | 'tx_status_received'
-    | 'tx_status_succeded'
+    | 'tx_status_succeeded'
     | 'tx_status_failed';
   submittedBlockIndex: StringUInt64 | null;
   transactionLogId: StringHex;


### PR DESCRIPTION
### Motivation

Fixes typescript enum typo, `tx_status_succeded` -> `tx_status_succeeded`.

Now correctly matches full-service:

https://github.com/mobilecoinofficial/full-service/blob/ab4a7ddfc3812988812cf5f63d4bd65bcebfb286/full-service/src/json_rpc/transaction_log.rs#L66

### In this PR

Did a search for the typo string, to look for any other references to it, but didn't see any.
