### PR TITLE
Ignore signer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ full-service-bin/*/full-service
 full-service-bin/*.css
 full-service-bin/full-service
 full-service-bin/*.sh
+full-service-bin/*/transaction-signer
+full-service-bin/transaction-signer


### PR DESCRIPTION
adds the transaction signer to the gitignore file to clean up development environments