### PR TITLE
Add high limits for txo and transaction log requests

### DIFF
--- a/app/fullService/api/getAllTransactionLogsForAccount.ts
+++ b/app/fullService/api/getAllTransactionLogsForAccount.ts
@@ -27,6 +27,7 @@ const getAllTransactionLogsForAccount = async ({
     GET_ALL_TRANSACTION_LOGS_FOR_ACCOUNT_METHOD,
     {
       accountId,
+      limit: 10000,
     }
   );
 

--- a/app/fullService/api/getAllTxosForAccount.ts
+++ b/app/fullService/api/getAllTxosForAccount.ts
@@ -28,6 +28,7 @@ export const getTxosV2 = async ({ accountId }: GetAllTxosByAccountParams): Promi
     GET_ALL_TXOS_FOR_ACCOUNT_METHOD,
     {
       accountId,
+      limit: 10000,
     }
   );
   if (error) {


### PR DESCRIPTION
Full service adds a default limit or 100 to these requests. We don't wanna take the time to implement pagination in desktop wallet right now, so I'm adding a limit of 10k to unblock people who are running into that 100 record limit