### PR TITLE
Fix Confirmations in new version

### DIFF
--- a/app/fullService/api/transactionLogVersionConversion.ts
+++ b/app/fullService/api/transactionLogVersionConversion.ts
@@ -35,20 +35,27 @@ export function mapTxoToAbbreviation(txo: InputTxo | OutputTxo): TransactionAbbr
 
   return {
     recipientAddressId: address,
-    txoIdHex: txo.txOutProto,
+    txoIdHex: txo.txoIdHex,
     valuePmob: txo.amount.value,
+  };
+}
+
+export function mapTxoV2ToAbbreviation(txo: TxoV2): TransactionAbbreviation {
+  return {
+    recipientAddressId: null,
+    txoIdHex: txo.id,
+    valuePmob: txo.value,
   };
 }
 
 export function convertTransactionLogFromV2(v2TransactionLog: TransactionLogV2): TransactionLog {
   const assignedAddressId = v2TransactionLog.outputTxos[0].recipientPublicAddressB58;
-
   const direction = 'tx_direction_sent';
 
   return {
     accountId: v2TransactionLog.accountId,
     assignedAddressId,
-    changeTxoIds: v2TransactionLog.changeTxos.map((t) => t.txOutProto),
+    changeTxoIds: v2TransactionLog.changeTxos.map((t) => t.txoIdHex),
     changeTxos: v2TransactionLog.changeTxos.map((t) => mapTxoToAbbreviation(t)),
     comment: v2TransactionLog.comment,
     contact: undefined,
@@ -57,11 +64,11 @@ export function convertTransactionLogFromV2(v2TransactionLog: TransactionLogV2):
     failureMessage: null,
     feePmob: v2TransactionLog.feeAmount.value,
     finalizedBlockIndex: v2TransactionLog.finalizedBlockIndex,
-    inputTxoIds: v2TransactionLog.inputTxos.map((t) => t.txOutProto),
+    inputTxoIds: v2TransactionLog.inputTxos.map((t) => t.txoIdHex),
     inputTxos: v2TransactionLog.inputTxos.map((t) => mapTxoToAbbreviation(t)),
     object: 'transaction_log',
     offsetCount: 0,
-    outputTxoIds: v2TransactionLog.outputTxos.map((t) => t.txOutProto),
+    outputTxoIds: v2TransactionLog.outputTxos.map((t) => t.txoIdHex),
     outputTxos: v2TransactionLog.outputTxos.map((t) => mapTxoToAbbreviation(t)),
     recipientAddressId: assignedAddressId,
     sentTime: v2TransactionLog.sentTime,
@@ -108,8 +115,8 @@ function convertTxoToTransactionLog(
     inputTxos: [],
     object: 'transaction_log',
     offsetCount: 0,
-    outputTxoIds: [],
-    outputTxos: [],
+    outputTxoIds: [txo.id],
+    outputTxos: [mapTxoV2ToAbbreviation(txo)],
     recipientAddressId: address,
     sentTime: null,
     status: matchStatus(txo.status),

--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -64,7 +64,9 @@ export const HistoryPage: FC = (): JSX.Element => {
         const result = await getConfirmations({
           transactionLogId: currentTransactionLog.transactionLogId,
         });
-        clipboard.writeText(JSON.stringify(result.confirmations));
+        // newer versions of full service use txoId instead of txoIdHex
+        // replace newer field with older to maintain backwards compatibility
+        clipboard.writeText(JSON.stringify(result.confirmations).replace(/txoId/, 'txoIdHex'));
         enqueueSnackbar('Copied Confirmations to Clipboard');
       } catch (err) {
         const errorMessage = errorToString(err);

--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -79,9 +79,12 @@ export const HistoryPage: FC = (): JSX.Element => {
     (async () => {
       const confirmationsString = clipboard.readText();
       try {
-        const confirmations = JSON.parse(confirmationsString) as Confirmations;
+        const confirmations = JSON.parse(
+          confirmationsString.replace(/"txoId"/, '"txoIdHex"')
+        ) as Confirmations;
         const results: { [txoId: string]: boolean } = {};
-
+        // newer versions of full service use txoId instead of txoIdHex
+        // replace newer field with older to maintain backwards compatibility
         await Promise.all(
           confirmations.map(async (confirmation) => {
             try {

--- a/app/types/TxProposal.d.ts
+++ b/app/types/TxProposal.d.ts
@@ -15,14 +15,14 @@ type Outlay = {
 };
 
 type InputTxo = {
-  txOutProto: string;
+  txoIdHex: string;
   amount: TransactionAmount;
   subaddressIndex: StringUInt64;
   keyImage: string;
 };
 
 type OutputTxo = {
-  txOutProto: string;
+  txoIdHex: string;
   amount: TransactionAmount;
   recipientPublicAddressB58: StringB58;
   confirmationNumber: StringUInt64;


### PR DESCRIPTION
FS 2/1.10 renamed the txoIdHex field to txoId in the getConfirmations query. Desktop wallet expects txoIdHex. In order to maintain compatibility between older and newer versions of the desktop wallet, use regex to replace txoId with txoIdHex before copying the confirmation to the clipboard.

This PR also fixes a few data mapping problems that were introduced with the first PR updating DW to use FS 2 API