### PR TITLE
Add Token selection UI and redux connection

### DIFF
--- a/app/constants/app.ts
+++ b/app/constants/app.ts
@@ -17,4 +17,5 @@ export const randomColor = (): string =>
 
 export enum TokenIds {
   MOB = 0,
+  MOBUSD = 1,
 }

--- a/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.test.tsx
+++ b/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.test.tsx
@@ -1,36 +1,54 @@
 import React from 'react';
 
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
 import '../../../testUtils/i18nForTests';
 
+import { store } from '../../../redux/store';
 import { BalanceIndicator } from './BalanceIndicator.view';
 
 const MOCK_BALANCE = '10.000000000000';
 
 describe('BalanceIndicator', () => {
   test('renders the correct balance', () => {
-    render(<BalanceIndicator balance={MOCK_BALANCE} isSynced />);
+    render(
+      <Provider store={store}>
+        <BalanceIndicator balance={MOCK_BALANCE} isSynced />
+      </Provider>
+    );
 
     const balanceIndicator = screen.getByTestId('balance-figure');
     expect(balanceIndicator).toHaveTextContent('10.000000000000');
   });
 
   test('renders 0 balance when balance prop is empty string', () => {
-    render(<BalanceIndicator balance="" isSynced />);
+    render(
+      <Provider store={store}>
+        <BalanceIndicator balance="" isSynced />
+      </Provider>
+    );
 
     const balanceIndicator = screen.getByTestId('balance-figure');
     expect(balanceIndicator).toHaveTextContent('0.000000000000');
   });
 
   test('renders no sync message if synced to ledger', () => {
-    render(<BalanceIndicator balance={MOCK_BALANCE} isSynced />);
+    render(
+      <Provider store={store}>
+        <BalanceIndicator balance={MOCK_BALANCE} isSynced />
+      </Provider>
+    );
 
     expect(screen.queryByTestId('balance-sync-message')).toBeNull();
   });
 
   test('renders sync message if not synced to ledger', () => {
-    render(<BalanceIndicator balance={MOCK_BALANCE} isSynced={false} />);
+    render(
+      <Provider store={store}>
+        <BalanceIndicator balance={MOCK_BALANCE} isSynced={false} />
+      </Provider>
+    );
 
     expect(screen.queryByTestId('balance-sync-message')).not.toBeNull();
   });

--- a/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
+++ b/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
@@ -62,8 +62,14 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
   const classes = useStyles();
   const matches = useMediaQuery('(min-height:768px)');
   const { tokenId } = useSelector((state: ReduxStoreState) => state);
-
   const { t } = useTranslation('BalanceIndicator');
+
+  const renderIcon = (token: TokenIds) =>
+    token === TokenIds.MOB ? (
+      <MOBIcon className={classes.iconElement} />
+    ) : (
+      <MonetizationOnOutlinedIcon className={classes.icon} />
+    );
 
   return (
     <Box className={classes.item} style={matches ? {} : { padding: '0' }}>
@@ -75,24 +81,14 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
           value={tokenId}
           classes={{ icon: classes.icon, iconOpen: classes.iconOpen, select: classes.selectSelect }}
           onChange={(e) => setTokenId(e.target.value as TokenIds)}
-          renderValue={(value: any) =>
-            value === TokenIds.MOB ? (
-              <MOBIcon className={classes.iconElement} />
-            ) : (
-              <MonetizationOnOutlinedIcon className={classes.icon} />
-            )
-          }
+          renderValue={(value: any) => renderIcon(value)}
         >
           <MenuItem value={TokenIds.MOB}>
-            <ListItemIcon>
-              <MOBIcon className={classes.iconElement} />
-            </ListItemIcon>
+            <ListItemIcon>{renderIcon(TokenIds.MOB)}</ListItemIcon>
             MOB
           </MenuItem>
           <MenuItem value={TokenIds.MOBUSD}>
-            <ListItemIcon>
-              <MonetizationOnOutlinedIcon className={classes.iconElement} />
-            </ListItemIcon>
+            <ListItemIcon>{renderIcon(TokenIds.MOBUSD)}</ListItemIcon>
             MobileUSD
           </MenuItem>
         </Select>

--- a/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
+++ b/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { FC } from 'react';
 
 import {
@@ -13,22 +13,38 @@ import {
 } from '@material-ui/core';
 import MonetizationOnOutlinedIcon from '@material-ui/icons/MonetizationOn';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import { MOBNumberFormat } from '../../../components';
 import { MOBIcon } from '../../../components/icons';
 import { TokenIds } from '../../../constants/app';
 import { GOLD_LIGHT } from '../../../constants/colors';
+import { ReduxStoreState } from '../../../redux/reducers/reducers';
+import { setTokenId } from '../../../redux/services';
 import { Theme } from '../../../theme';
 import { BalanceIndicatorProps } from './BalanceIndicator';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  formControlLabel: {
+    left: 24,
+  },
   icon: {
+    left: 0,
+  },
+  iconElement: {
     height: 24,
     width: 24,
+  },
+  iconOpen: {
+    transform: 'none',
   },
   item: {
     padding: theme.spacing(3, 0, 0, 0),
     textAlign: 'center',
+  },
+  selectSelect: {
+    paddingLeft: '24px',
+    paddingRight: '8px !important',
   },
   valueContainer: {
     alignItems: 'center',
@@ -45,7 +61,7 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
 }: BalanceIndicatorProps) => {
   const classes = useStyles();
   const matches = useMediaQuery('(min-height:768px)');
-  const [icon, setIcon] = useState(TokenIds.MOB);
+  const { tokenId } = useSelector((state: ReduxStoreState) => state);
 
   const { t } = useTranslation('BalanceIndicator');
 
@@ -56,14 +72,12 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
       </Typography>
       <Box className={classes.valueContainer}>
         <Select
-          value={icon}
-          style={{ marginRight: 4 }}
-          SelectDisplayProps={{ style: { paddingBottom: 4, paddingLeft: 8, paddingRight: 8 } }}
-          onChange={(e) => setIcon(e.target.value as TokenIds)}
-          IconComponent={() => null}
+          value={tokenId}
+          classes={{ icon: classes.icon, iconOpen: classes.iconOpen, select: classes.selectSelect }}
+          onChange={(e) => setTokenId(e.target.value as TokenIds)}
           renderValue={(value: any) =>
             value === TokenIds.MOB ? (
-              <MOBIcon className={classes.icon} />
+              <MOBIcon className={classes.iconElement} />
             ) : (
               <MonetizationOnOutlinedIcon className={classes.icon} />
             )
@@ -71,13 +85,13 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
         >
           <MenuItem value={TokenIds.MOB}>
             <ListItemIcon>
-              <MOBIcon className={classes.icon} />
+              <MOBIcon className={classes.iconElement} />
             </ListItemIcon>
             MOB
           </MenuItem>
           <MenuItem value={TokenIds.MOBUSD}>
             <ListItemIcon>
-              <MonetizationOnOutlinedIcon className={classes.icon} />
+              <MonetizationOnOutlinedIcon className={classes.iconElement} />
             </ListItemIcon>
             MobileUSD
           </MenuItem>

--- a/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
+++ b/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
@@ -1,20 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { FC } from 'react';
 
-import { Box, Button, makeStyles, Typography, useMediaQuery } from '@material-ui/core';
+import {
+  Box,
+  Button,
+  makeStyles,
+  Typography,
+  useMediaQuery,
+  Select,
+  MenuItem,
+  ListItemIcon,
+} from '@material-ui/core';
+import MonetizationOnOutlinedIcon from '@material-ui/icons/MonetizationOn';
 import { useTranslation } from 'react-i18next';
 
 import { MOBNumberFormat } from '../../../components';
 import { MOBIcon } from '../../../components/icons';
+import { TokenIds } from '../../../constants/app';
 import { GOLD_LIGHT } from '../../../constants/colors';
 import { Theme } from '../../../theme';
 import { BalanceIndicatorProps } from './BalanceIndicator';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
-    height: 25,
-    paddingRight: 5,
-    width: 25,
+    height: 24,
+    width: 24,
   },
   item: {
     padding: theme.spacing(3, 0, 0, 0),
@@ -35,6 +45,7 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
 }: BalanceIndicatorProps) => {
   const classes = useStyles();
   const matches = useMediaQuery('(min-height:768px)');
+  const [icon, setIcon] = useState(TokenIds.MOB);
 
   const { t } = useTranslation('BalanceIndicator');
 
@@ -44,7 +55,33 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
         {t('title')}
       </Typography>
       <Box className={classes.valueContainer}>
-        <MOBIcon className={classes.icon} />
+        <Select
+          value={icon}
+          style={{ marginRight: 4 }}
+          SelectDisplayProps={{ style: { paddingBottom: 4, paddingLeft: 8, paddingRight: 8 } }}
+          onChange={(e) => setIcon(e.target.value as TokenIds)}
+          IconComponent={() => null}
+          renderValue={(value: any) =>
+            value === TokenIds.MOB ? (
+              <MOBIcon className={classes.icon} />
+            ) : (
+              <MonetizationOnOutlinedIcon className={classes.icon} />
+            )
+          }
+        >
+          <MenuItem value={TokenIds.MOB}>
+            <ListItemIcon>
+              <MOBIcon className={classes.icon} />
+            </ListItemIcon>
+            MOB
+          </MenuItem>
+          <MenuItem value={TokenIds.MOBUSD}>
+            <ListItemIcon>
+              <MonetizationOnOutlinedIcon className={classes.icon} />
+            </ListItemIcon>
+            MobileUSD
+          </MenuItem>
+        </Select>
         <Typography data-testid="balance-figure" variant="h3" color="textPrimary">
           <MOBNumberFormat valueUnit="pMOB" value={balance} />
         </Typography>

--- a/app/redux/actions/index.ts
+++ b/app/redux/actions/index.ts
@@ -27,6 +27,7 @@ import { getFeePmobAction, GetFeePmobAction, GET_FEE_PMOB } from './getFeePmobAc
 import { importAccountAction, IMPORT_ACCOUNT, ImportAccountAction } from './importAccountAction';
 import { initializeAction, INITIALIZE, InitializeAction } from './initializeAction';
 import { selectAccountAction, SELECT_ACCOUNT, SelectAccountAction } from './selectAccountAction';
+import { SET_TOKEN_ID, setTokenIdAction, SetTokenIdAction } from './setTokenIdAction';
 import { unlockWalletAction, UNLOCK_WALLET, UnlockWalletAction } from './unlockWalletAction';
 import {
   updateContactsAction,
@@ -61,6 +62,7 @@ export {
   UPDATE_PASSWORD,
   UPDATE_PIN,
   UPDATE_WALLET_STATUS,
+  SET_TOKEN_ID,
 };
 
 type Action =
@@ -77,6 +79,7 @@ type Action =
   | ImportAccountAction
   | InitializeAction
   | SelectAccountAction
+  | SetTokenIdAction
   | UnlockWalletAction
   | UpdateContactsAction
   | UpdatePasswordAction
@@ -98,6 +101,7 @@ export type {
   ImportAccountAction,
   InitializeAction,
   SelectAccountAction,
+  SetTokenIdAction,
   UnlockWalletAction,
   UpdateContactsAction,
   GetAllGiftCodesAction,
@@ -120,6 +124,7 @@ export {
   importAccountAction,
   initializeAction,
   selectAccountAction,
+  setTokenIdAction,
   unlockWalletAction,
   updateContactsAction,
   getAllGiftCodesAction,

--- a/app/redux/actions/setTokenIdAction.ts
+++ b/app/redux/actions/setTokenIdAction.ts
@@ -1,0 +1,17 @@
+import { TokenIds } from '../../constants/app';
+
+export const SET_TOKEN_ID = 'SET_TOKEN_ID';
+
+export type SetTokenIdAction = {
+  type: 'SET_TOKEN_ID';
+  payload: {
+    tokenId: TokenIds;
+  };
+};
+
+export const setTokenIdAction = (tokenId: TokenIds): SetTokenIdAction => ({
+  payload: {
+    tokenId,
+  },
+  type: SET_TOKEN_ID,
+});

--- a/app/redux/reducers/reducers.ts
+++ b/app/redux/reducers/reducers.ts
@@ -1,5 +1,6 @@
 import { SjclCipherEncrypted } from 'sjcl';
 
+import { TokenIds } from '../../constants/app';
 import {
   Accounts,
   Addresses,
@@ -49,6 +50,8 @@ import {
   Action,
   GET_ALL_TRANSACTION_LOGS_FOR_ACCOUNT,
   GetAllTransactionLogsForAccountAction,
+  SET_TOKEN_ID,
+  SetTokenIdAction,
 } from '../actions';
 
 export type ReduxStoreState = {
@@ -72,6 +75,7 @@ export type ReduxStoreState = {
   pin: string | undefined;
   txos: Txos;
   walletStatus: WalletStatus;
+  tokenId: TokenIds;
 };
 
 export const initialReduxStoreState: ReduxStoreState = {
@@ -111,6 +115,7 @@ export const initialReduxStoreState: ReduxStoreState = {
       unspentPmob: '',
     },
   },
+  tokenId: TokenIds.MOB,
   transactionLogs: null,
   txos: { txoIds: [], txoMap: {} },
   walletStatus: {
@@ -324,6 +329,14 @@ export const reducer = (
             selectedAccount,
             walletStatus,
           };
+    }
+
+    case SET_TOKEN_ID: {
+      const { tokenId } = (action as SetTokenIdAction).payload;
+      return {
+        ...state,
+        tokenId,
+      };
     }
 
     default: {

--- a/app/redux/services/index.ts
+++ b/app/redux/services/index.ts
@@ -11,6 +11,7 @@ import { getFeePmob } from './getFeePmob';
 import { importAccount, importLegacyAccount } from './importAccount';
 import { initialize } from './initialize';
 import { selectAccount } from './selectAccount';
+import { setTokenId } from './setTokenId';
 import { unlockWallet } from './unlockWallet';
 import { updateContacts } from './updateContacts';
 import { updatePassword } from './updatePassword';
@@ -32,6 +33,7 @@ export {
   importLegacyAccount,
   initialize,
   selectAccount,
+  setTokenId,
   unlockWallet,
   updateContacts,
   updatePassword,

--- a/app/redux/services/setTokenId.ts
+++ b/app/redux/services/setTokenId.ts
@@ -1,0 +1,7 @@
+import { TokenIds } from '../../constants/app';
+import { setTokenIdAction } from '../actions';
+import { store } from '../store';
+
+export const setTokenId = async (tokenId: TokenIds): Promise<void> => {
+  store.dispatch(setTokenIdAction(tokenId));
+};


### PR DESCRIPTION
<img width="635" alt="Screen Shot 2022-09-14 at 6 05 27 PM" src="https://user-images.githubusercontent.com/12504542/190463971-506638c9-263e-4aad-90b5-5972f47bef79.png">
<img width="735" alt="Screen Shot 2022-09-14 at 2 03 12 PM" src="https://user-images.githubusercontent.com/12504542/190464084-55ddac54-6d6a-4844-b425-ad44a4755eae.png">

Add dropdown for selection MOB or MOBUSD in the balance header component. This allows the user to always see/select the token type no matter which page they are on.

Token ID is stored in the redux store. Right now it's only used to determine the token icon UI, but it will be used to determine which token is used for balance, transactions, history etc (coming in future PRs!)

UI isn't 100% pixel perfect right now. Going to leave it like this until I get more feedback from design.
