### PR TITLE
Remove change from transaction history

### DIFF
--- a/app/fullService/api/transactionLogVersionConversion.ts
+++ b/app/fullService/api/transactionLogVersionConversion.ts
@@ -47,6 +47,7 @@ export function mapTxoV2ToAbbreviation(txo: TxoV2): TransactionAbbreviation {
   };
 }
 
+// all transaction logs are sent txos
 export function convertTransactionLogFromV2(v2TransactionLog: TransactionLogV2): TransactionLog {
   const assignedAddressId = v2TransactionLog.outputTxos[0].recipientPublicAddressB58;
   const direction = 'tx_direction_sent';
@@ -96,6 +97,7 @@ export function convertTransactionLogsResponseFromV2(
   };
 }
 
+// all txos are received txos
 function convertTxoToTransactionLog(
   txo: TxoV2,
   accountId: StringB58,
@@ -123,6 +125,7 @@ function convertTxoToTransactionLog(
     sentTime: null,
     status: matchStatus(txo.status),
     submittedBlockIndex: null,
+    subaddressIndex: txo.subaddressIndex,
     transactionLogId: txo.id,
     tokenId: Number(txo.tokenId),
     value: txo.value,

--- a/app/hooks/useTransactionLogs.ts
+++ b/app/hooks/useTransactionLogs.ts
@@ -1,0 +1,33 @@
+import { useSelector } from 'react-redux';
+
+import { ReduxStoreState } from '../redux/reducers/reducers';
+import type { TransactionLog } from '../types/TransactionLog.d';
+
+const CHANGESUBADDRESSES = ['18446744073709551614', '1'];
+
+export const useTransactionLogs: () => TransactionLog[] = () => {
+  const { contacts, transactionLogs, tokenId } = useSelector((state: ReduxStoreState) => state);
+
+  const logs: TransactionLog[] = transactionLogs
+    ? transactionLogs.transactionLogIds
+        .map((id) => transactionLogs.transactionLogMap[id])
+        .map((transactionLog) => {
+          // If any transaction is associated to a contact, let's attach the contact object.
+          // TODO - we can improve this greatly by changing how this information is stored.
+          const contact = contacts.find(
+            (x) =>
+              x.assignedAddress === transactionLog.assignedAddressId ||
+              x.recipientAddress === transactionLog.recipientAddressId
+          );
+          if (contact) {
+            transactionLog.contact = contact; /* eslint-disable-line no-param-reassign */
+          }
+          return transactionLog;
+        })
+        .filter((log) => log.tokenId === tokenId)
+        .filter((log) => !log.subaddressIndex || !CHANGESUBADDRESSES.includes(log.subaddressIndex))
+        .sort((a, b) => b.finalizedBlockIndex - a.finalizedBlockIndex)
+    : ([] as TransactionLog[]);
+
+  return logs;
+};

--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -16,40 +16,20 @@ import type { TransactionLog } from '../../../types/TransactionLog.d';
 import { errorToString } from '../../../utils/errorHandler';
 import { HistoryList } from '../HistoryList.view';
 import { TransactionDetails } from '../TransactionDetails.view';
+import { useTransactionLogs } from '../../../hooks/useTransactionLogs';
 
 const HISTORY = 'history';
 const DETAILS = 'details';
 
 export const HistoryPage: FC = (): JSX.Element => {
-  const { contacts, selectedAccount, transactionLogs, tokenId } = useSelector(
-    (state: ReduxStoreState) => state
-  );
+  const { selectedAccount, transactionLogs } = useSelector((state: ReduxStoreState) => state);
 
   const [currentTransactionLog, setCurrentTransaction] = useState({} as TransactionLog);
   const [txoValidations, setTxoValidations] = useState({});
   const [showing, setShowing] = useState(HISTORY);
   const { t } = useTranslation('HistoryView');
   const { enqueueSnackbar } = useSnackbar();
-
-  const logs: TransactionLog[] = transactionLogs
-    ? transactionLogs.transactionLogIds
-        .map((id) => transactionLogs.transactionLogMap[id])
-        .map((transactionLog) => {
-          // If any transaction is associated to a contact, let's attach the contact object.
-          // TODO - we can improve this greatly by changing how this information is stored.
-          const contact = contacts.find(
-            (x) =>
-              x.assignedAddress === transactionLog.assignedAddressId ||
-              x.recipientAddress === transactionLog.recipientAddressId
-          );
-          if (contact) {
-            transactionLog.contact = contact; /* eslint-disable-line no-param-reassign */
-          }
-          return transactionLog;
-        })
-        .filter((log) => log.tokenId === tokenId)
-        .sort((a, b) => b.finalizedBlockIndex - a.finalizedBlockIndex)
-    : ([] as TransactionLog[]);
+  const logs = useTransactionLogs();
 
   const handleClickCopyConfirmations = () => {
     (async () => {

--- a/app/types/Address.d.ts
+++ b/app/types/Address.d.ts
@@ -3,16 +3,16 @@ import type { StringB58, StringHex, StringUInt64 } from './SpecialStrings';
 export interface Address {
   // A b58 encoding of the public address materials.
   // The public_address is the unique identifier for the address.
-  public_address_b58: StringB58;
+  publicAddressB58: StringB58;
 
   // The account which owns this address.
-  account_id: StringHex;
+  accountId: StringHex;
 
   // Additional data associated with this address.
   metadata: string;
 
   // The index of this address in the subaddress space for the account.
-  subaddress_index: StringUInt64;
+  subaddressIndex: StringUInt64;
 }
 
 export type Addresses = {

--- a/app/types/TransactionLog.d.ts
+++ b/app/types/TransactionLog.d.ts
@@ -30,6 +30,7 @@ export interface TransactionLog {
   recipientAddressId: StringB58;
   sentTime: string | null; // FIX-ME: Confirm type
   status: Status;
+  subaddressIndex?: StringUInt64;
   submittedBlockIndex: StringUInt64 | null;
   transactionLogId: StringHex;
   tokenId: number;


### PR DESCRIPTION
- Move tx log filtering + contact logic to a standalone hook to make history component easier to read.
- add subaddress index field to tx log type
- filter out change txs using subaddress index