### PR TITLE
improved filtering of change from history

### DIFF
--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -16,7 +16,6 @@ import type { TransactionLog } from '../../../types/TransactionLog.d';
 import { errorToString } from '../../../utils/errorHandler';
 import { HistoryList } from '../HistoryList.view';
 import { TransactionDetails } from '../TransactionDetails.view';
-import { getValuesFromArgTypes } from '@storybook/store';
 
 const HISTORY = 'history';
 const DETAILS = 'details';

--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -38,10 +38,10 @@ export const HistoryPage: FC = (): JSX.Element => {
       let changeAddressId = "None";
       let legacyChangeAddressId = "None";
 
-      let myAddresses = Object.values(addresses.addressMap)
       // find the public addresses for this account that correspond to the current and legacy change addresses.
       // for all accounts, the current change address is at subaddress index 18446744073709551614 (largest u64 minus 1)
       // for all accounts, the legacy change address is at subaddress index 1
+      let myAddresses = Object.values(addresses.addressMap)
       myAddresses.forEach((address) => {
         if (address.subaddressIndex == "18446744073709551614") {
           changeAddressId = address.publicAddress;

--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -39,6 +39,9 @@ export const HistoryPage: FC = (): JSX.Element => {
       let legacyChangeAddressId = "None";
 
       let myAddresses = Object.values(addresses.addressMap)
+      // find the public addresses for this account that correspond to the current and legacy change addresses.
+      // for all accounts, the current change address is at subaddress index 18446744073709551614 (largest u64 minus 1)
+      // for all accounts, the legacy change address is at subaddress index 1
       myAddresses.forEach((address) => {
         if (address.subaddressIndex == "18446744073709551614") {
           changeAddressId = address.publicAddress;

--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -16,6 +16,7 @@ import type { TransactionLog } from '../../../types/TransactionLog.d';
 import { errorToString } from '../../../utils/errorHandler';
 import { HistoryList } from '../HistoryList.view';
 import { TransactionDetails } from '../TransactionDetails.view';
+import { getValuesFromArgTypes } from '@storybook/store';
 
 const HISTORY = 'history';
 const DETAILS = 'details';
@@ -34,9 +35,24 @@ export const HistoryPage: FC = (): JSX.Element => {
 
   const buildList = (): TransactionLog[] => {
     if (transactionLogs) {
+
+      let changeAddressId = "None";
+      let legacyChangeAddressId = "None";
+
+      let myAddresses = Object.values(addresses.addressMap)
+      myAddresses.forEach((address) => {
+        if (address.subaddressIndex == "18446744073709551614") {
+          changeAddressId = address.publicAddress;
+        }
+        if (address.subaddressIndex == "1") {
+          legacyChangeAddressId = address.publicAddress;
+        }
+      });
+
       return transactionLogs.transactionLogIds
         .map((id) => transactionLogs.transactionLogMap[id])
-        .filter((transactionLog) => transactionLog.assignedAddressId !== addresses.addressIds[1])
+        .filter((transactionLog) => transactionLog.assignedAddressId !== legacyChangeAddressId)
+        .filter((transactionLog) => transactionLog.assignedAddressId !== changeAddressId)
         .map((transactionLog) => {
           // If any transaction is associated to a contact, let's attach the contact object.
           // TODO - we can improve this greatly by changing how this information is stored.


### PR DESCRIPTION
### Motivation

Currently, the v1.6/develop branch of desktop-wallet (as well as main, actually) is not aware of the new change subaddress at u64:max - 1, and thus shows change in the transaction history.

Also, the technique for filtering out legacy change from the transaction history relies on the order that subaddress indexes were created by full-service, which is unnecessarily fragile.

### In this PR

Added code to lookup the public addresses that correspond to the legacy change subaddress index 1 and [current] change subaddress index `uint:max -1`, and filter out any transaction for both from the transaction history page.

### Caveats

The develop branch has addressed this issue in another way, but as it is also majorly refactored to use the full-service v2 api, back porting was deemed more work than making this update.

This PR will be unnecessary once we release the ongoing work in the develop branch, but in the meantime, in case there is another v1.6 release, it would be good to eliminate the "mysterious" extra entries that have been appearing in the transaction history
