### PR TITLE
Remove account secrets from account model

### DIFF
--- a/app/fullService/api/getAccount.ts
+++ b/app/fullService/api/getAccount.ts
@@ -1,9 +1,7 @@
 import { store } from '../../redux/store';
 import type { Account, AccountStatus } from '../../types/Account.d';
-import type { AccountSecretsV2 } from '../../types/AccountSecrets.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
-import { exportAccountSecretsV2 } from './exportAccountSecrets';
 
 const GET_ACCOUNT_METHOD = 'get_account_status';
 
@@ -15,22 +13,15 @@ type GetAccountResult = {
   account: Account;
 };
 
-export function convertAccountV2(
-  accountStatus: AccountStatus,
-  accountSecrets: AccountSecretsV2
-): GetAccountResult {
+export function convertAccountV2(accountStatus: AccountStatus): GetAccountResult {
   return {
     account: {
       accountHeight: accountStatus.account.nextBlockIndex,
       accountId: accountStatus.account.id,
-      accountKey: accountSecrets.accountKey,
-      entropy: accountSecrets.entropy,
       firstBlockIndex: accountStatus.account.firstBlockIndex,
-      keyDerivationVersion: accountSecrets.keyDerivationVersion,
       mainAddress: accountStatus.account.mainAddress,
       name: accountStatus.account.name,
       nextSubaddressIndex: accountStatus.account.nextSubaddressIndex,
-      object: 'account',
       recoveryMode: accountStatus.account.recoveryMode,
     },
   };
@@ -59,8 +50,6 @@ export const isAccountSynced = async ({ accountId }: GetAccountParams): Promise<
 };
 
 const getAccount = async ({ accountId }: GetAccountParams): Promise<GetAccountResult> => {
-  const secrets = await exportAccountSecretsV2({ accountId });
-
   const { result, error }: AxiosFullServiceResponse<AccountStatus> = await axiosFullService(
     GET_ACCOUNT_METHOD,
     {
@@ -73,7 +62,7 @@ const getAccount = async ({ accountId }: GetAccountParams): Promise<GetAccountRe
   } else if (!result) {
     throw new Error('Failure to retrieve data.');
   } else {
-    return convertAccountV2(result, secrets.accountSecrets);
+    return convertAccountV2(result);
   }
 };
 

--- a/app/layouts/DashboardLayout/DashboardLayout.presenter/DashboardLayout.presenter.tsx
+++ b/app/layouts/DashboardLayout/DashboardLayout.presenter/DashboardLayout.presenter.tsx
@@ -46,14 +46,8 @@ const useStyles = makeStyles((theme: Theme) => ({
 export const DashboardLayout: FC<DashboardLayoutProps> = (
   props: DashboardLayoutProps
 ): JSX.Element => {
-  const {
-    offlineModeEnabled,
-    selectedAccount,
-    isEntropyKnown,
-    isPinRequired,
-    pendingSecrets,
-    tokenId,
-  } = useSelector((state: ReduxStoreState) => state);
+  const { offlineModeEnabled, selectedAccount, isEntropyKnown, isPinRequired, tokenId } =
+    useSelector((state: ReduxStoreState) => state);
   const { children } = props;
   const classes = useStyles();
   const matches = useMediaQuery('(min-height:768px)');
@@ -97,7 +91,6 @@ export const DashboardLayout: FC<DashboardLayoutProps> = (
             confirmEntropyKnown={confirmEntropyKnown}
             isEntropyKnown={isEntropyKnown}
             isPinRequired={isPinRequired}
-            pendingSecrets={pendingSecrets}
             updatePin={updatePin}
           />
         </Box>

--- a/app/layouts/DashboardLayout/OnboardingModal.view/OnboardingModal.d.ts
+++ b/app/layouts/DashboardLayout/OnboardingModal.view/OnboardingModal.d.ts
@@ -1,15 +1,8 @@
 import { UpdatePinService } from '../../../redux/services/updatePin';
-import type { StringHex } from '../../../types/SpecialStrings.d';
-
-type PendingSecrets = {
-  entropy: StringHex;
-  mnemonic: string;
-};
 
 export interface OnboardingModalProps {
-  confirmEntropyKnown: () => Promise<void>;
+  confirmEntropyKnown: () => void;
   isEntropyKnown: boolean;
   isPinRequired: boolean;
-  pendingSecrets: PendingSecrets | null;
   updatePin: UpdatePinService;
 }

--- a/app/layouts/DashboardLayout/OnboardingModal.view/OnboardingModal.test.tsx
+++ b/app/layouts/DashboardLayout/OnboardingModal.view/OnboardingModal.test.tsx
@@ -10,7 +10,6 @@ import { OnboardingModal } from './OnboardingModal.view';
 
 const confirmEntropyKnown = jest.fn();
 const updatePin = jest.fn();
-const pendingSecrets = null;
 const showEntropyMsg =
   'We generated a random Entropy to create your new account. Please store this code in a secure, private manner. You will need your Entropy to import this account into other wallets.';
 const setPinMsg =
@@ -23,7 +22,6 @@ describe('OnboardingModal', () => {
         <OnboardingModal
           confirmEntropyKnown={confirmEntropyKnown}
           updatePin={updatePin}
-          pendingSecrets={pendingSecrets}
           isEntropyKnown={false}
           isPinRequired
         />
@@ -39,7 +37,6 @@ describe('OnboardingModal', () => {
         <OnboardingModal
           confirmEntropyKnown={confirmEntropyKnown}
           updatePin={updatePin}
-          pendingSecrets={pendingSecrets}
           isEntropyKnown
           isPinRequired
         />
@@ -55,7 +52,6 @@ describe('OnboardingModal', () => {
         <OnboardingModal
           confirmEntropyKnown={confirmEntropyKnown}
           updatePin={updatePin}
-          pendingSecrets={pendingSecrets}
           isEntropyKnown
           isPinRequired={false}
         />

--- a/app/layouts/DashboardLayout/OnboardingModal.view/OnboardingModal.view.tsx
+++ b/app/layouts/DashboardLayout/OnboardingModal.view/OnboardingModal.view.tsx
@@ -9,18 +9,15 @@ const OnboardingModal: FC<OnboardingModalProps> = ({
   confirmEntropyKnown,
   isEntropyKnown,
   isPinRequired,
-  pendingSecrets,
   updatePin,
 }: OnboardingModalProps) => {
   const isShowEntropyModalShown = !isEntropyKnown;
   const isSetPinModalShown = isPinRequired;
-  const mnemonic = pendingSecrets?.mnemonic || '';
 
   if (isShowEntropyModalShown) {
     return (
       <ShowEntropyModal
         isShown={isShowEntropyModalShown}
-        mnemonic={mnemonic}
         confirmEntropyKnown={confirmEntropyKnown}
       />
     );

--- a/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.d.ts
+++ b/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.d.ts
@@ -1,5 +1,4 @@
 export interface ShowEntropyModalProps {
   isShown: boolean;
-  mnemonic: string;
   confirmEntropyKnown: () => void;
 }

--- a/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.test.tsx
+++ b/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.test.tsx
@@ -14,21 +14,13 @@ const showEntropyMsg = screen.queryByText(
 
 describe('ShowEntropyModal', () => {
   test('does not render modal when isShown set to false', () => {
-    render(
-      <ShowEntropyModal
-        confirmEntropyKnown={confirmEntropyKnown}
-        mnemonic={mnemonic}
-        isShown={false}
-      />
-    );
+    render(<ShowEntropyModal confirmEntropyKnown={confirmEntropyKnown} isShown={false} />);
 
     expect(showEntropyMsg).toBeNull();
   });
 
   test('mnemonic is hidden and shown based on toggle', () => {
-    render(
-      <ShowEntropyModal confirmEntropyKnown={confirmEntropyKnown} mnemonic={mnemonic} isShown />
-    );
+    render(<ShowEntropyModal confirmEntropyKnown={confirmEntropyKnown} isShown />);
 
     fireEvent.click(screen.getByText('Show Secret Entropy'));
     expect(screen.getByText(mnemonic)).toBeInTheDocument();

--- a/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.test.tsx
+++ b/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.test.tsx
@@ -1,30 +1,37 @@
 import React from 'react';
 
 import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
 import '@testing-library/jest-dom/extend-expect';
 import '../../../testUtils/i18nForTests';
-
+import { store } from '../../../redux/store';
 import { ShowEntropyModal } from './ShowEntropyModal.view';
 
 const confirmEntropyKnown = jest.fn();
-const mnemonic = 'test test test test';
 const showEntropyMsg = screen.queryByText(
   'We generated a random Entropy to create your new account. Please store this code in a secure, private manner. You will need your Entropy to import this account into other wallets.'
 );
 
 describe('ShowEntropyModal', () => {
   test('does not render modal when isShown set to false', () => {
-    render(<ShowEntropyModal confirmEntropyKnown={confirmEntropyKnown} isShown={false} />);
+    render(
+      <Provider store={store}>
+        <ShowEntropyModal confirmEntropyKnown={confirmEntropyKnown} isShown={false} />
+      </Provider>
+    );
 
     expect(showEntropyMsg).toBeNull();
   });
 
   test('mnemonic is hidden and shown based on toggle', () => {
-    render(<ShowEntropyModal confirmEntropyKnown={confirmEntropyKnown} isShown />);
+    render(
+      <Provider store={store}>
+        <ShowEntropyModal confirmEntropyKnown={confirmEntropyKnown} isShown />
+      </Provider>
+    );
 
     fireEvent.click(screen.getByText('Show Secret Entropy'));
-    expect(screen.getByText(mnemonic)).toBeInTheDocument();
-
     fireEvent.click(screen.getByText('I have secured my Entropy'));
     fireEvent.click(screen.getByText('Yes, I have secured my Entropy'));
     expect(confirmEntropyKnown).toHaveBeenCalled();

--- a/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.view.tsx
+++ b/app/layouts/DashboardLayout/ShowEntropyModal.view/ShowEntropyModal.view.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import type { FC } from 'react';
 
 import {
@@ -15,8 +15,12 @@ import {
   Typography,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
+import { exportAccountSecrets } from '../../../fullService/api';
+import { ReduxStoreState } from '../../../redux/reducers/reducers';
 import type { Theme } from '../../../theme';
+import { AccountSecrets } from '../../../types';
 import { ShowEntropyModalProps } from './ShowEntropyModal';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -39,14 +43,27 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const ShowEntropyModal: FC<ShowEntropyModalProps> = ({
   isShown,
-  mnemonic,
   confirmEntropyKnown,
 }: ShowEntropyModalProps) => {
+  const { selectedAccount } = useSelector((state: ReduxStoreState) => state);
+  const { accountId } = selectedAccount.account;
+  const [secrets, setSecrets] = useState<AccountSecrets | null>(null);
   const classes = useStyles();
   const [alertOpen, setAlertOpen] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const [showEntropy, setShowEntropy] = useState(false);
   const { t } = useTranslation('ShowEntropyModal');
+
+  useEffect(() => {
+    const fetchSecrets = async () => {
+      const { accountSecrets } = await exportAccountSecrets({
+        accountId,
+      });
+      setSecrets(accountSecrets);
+    };
+
+    fetchSecrets();
+  }, [accountId]);
 
   const handleCloseModal = () => confirmEntropyKnown();
 
@@ -106,7 +123,7 @@ const ShowEntropyModal: FC<ShowEntropyModalProps> = ({
                   <Container maxWidth="sm">
                     <Box minHeight={60}>
                       <Typography variant="body2" color="textPrimary">
-                        {showEntropy ? mnemonic : ''}
+                        {showEntropy ? secrets?.mnemonic : ''}
                       </Typography>
                     </Box>
                   </Container>

--- a/app/redux/actions/createAccountAction.ts
+++ b/app/redux/actions/createAccountAction.ts
@@ -4,7 +4,6 @@ import {
   Address,
   Addresses,
   BalanceStatus,
-  PendingSecrets,
   SelectedAccount,
   StringHex,
   WalletStatus,
@@ -16,7 +15,6 @@ export type CreateAccountAction = {
   payload: {
     accounts: Accounts;
     addresses: Addresses;
-    pendingSecrets: PendingSecrets;
     selectedAccount: SelectedAccount;
     walletStatus: WalletStatus;
   };
@@ -28,7 +26,6 @@ export const createAccountAction = (
   accountMap: { [accountId: string]: Account },
   addressIds: StringHex[],
   addressMap: { [addressId: string]: Address },
-  pendingSecrets: PendingSecrets,
   account: Account,
   balanceStatus: BalanceStatus,
   walletStatus: WalletStatus
@@ -42,7 +39,6 @@ export const createAccountAction = (
       addressIds,
       addressMap,
     },
-    pendingSecrets,
     selectedAccount: {
       account,
       balanceStatus,

--- a/app/redux/reducers/reducers.ts
+++ b/app/redux/reducers/reducers.ts
@@ -6,7 +6,6 @@ import {
   Addresses,
   Contact,
   GiftCode,
-  PendingSecrets,
   SelectedAccount,
   StringUInt64,
   TransactionLogs,
@@ -68,7 +67,6 @@ export type ReduxStoreState = {
   isInitialized: boolean;
   isPinRequired: boolean;
   offlineModeEnabled: boolean;
-  pendingSecrets: PendingSecrets | null;
   secretKey: string;
   selectedAccount: SelectedAccount;
   transactionLogs: TransactionLogs | null;
@@ -92,7 +90,6 @@ export const initialReduxStoreState: ReduxStoreState = {
   isInitialized: false,
   isPinRequired: false,
   offlineModeEnabled: false,
-  pendingSecrets: null,
   pin: undefined,
   pinThresholdPmob: '',
   secretKey: '',
@@ -100,11 +97,9 @@ export const initialReduxStoreState: ReduxStoreState = {
     account: {
       accountId: '',
       firstBlockIndex: '',
-      keyDerivationVersion: '',
       mainAddress: '',
       name: '',
       nextSubaddressIndex: '',
-      object: 'account' as const,
       recoveryMode: false,
     },
     balanceStatus: {
@@ -173,14 +168,12 @@ export const reducer = (
       return {
         ...state,
         isEntropyKnown: true,
-        pendingSecrets: null, // Clear secrets from in-memory
       };
     }
 
     case CREATE_ACCOUNT: {
-      const { accounts, addresses, pendingSecrets, selectedAccount, walletStatus } = (
-        action as CreateAccountAction
-      ).payload;
+      const { accounts, addresses, selectedAccount, walletStatus } = (action as CreateAccountAction)
+        .payload;
       return {
         ...state,
         accounts,
@@ -188,7 +181,6 @@ export const reducer = (
         addresses,
         isAuthenticated: true,
         isEntropyKnown: false,
-        pendingSecrets,
         selectedAccount,
         walletStatus,
       };

--- a/app/redux/services/createAccount.ts
+++ b/app/redux/services/createAccount.ts
@@ -1,5 +1,4 @@
 import * as fullServiceApi from '../../fullService/api';
-import { PendingSecrets } from '../../types';
 import { errorToString } from '../../utils/errorHandler';
 import { createAccountAction } from '../actions';
 import { store } from '../store';
@@ -9,11 +8,6 @@ export const createAccount = async (name: string): Promise<void> => {
     // Attempt create
     const { account } = await fullServiceApi.createAccount({ name });
     const { accountId } = account;
-
-    // Get basic wallet information
-    const { accountSecrets: pendingSecrets } = await fullServiceApi.exportAccountSecrets({
-      accountId,
-    });
 
     const { walletStatus } = await fullServiceApi.getWalletStatus();
     const { accountIds, accountMap } = await fullServiceApi.getAllAccounts();
@@ -28,7 +22,6 @@ export const createAccount = async (name: string): Promise<void> => {
         accountMap,
         addressIds,
         addressMap,
-        pendingSecrets as PendingSecrets,
         account,
         balanceStatus,
         walletStatus

--- a/app/types/Account.d.ts
+++ b/app/types/Account.d.ts
@@ -1,20 +1,13 @@
-// TODO - change to just Account; delete the other Account type
-import type { AccountKey } from './AccountSecrets';
 import type { BalanceFromV2Api } from './BalanceStatus';
 import type { StringB58, StringHex, StringUInt64 } from './SpecialStrings';
 
 export interface Account {
-  // metadata: string used as a wildcard, stringified json object?
   accountId: StringHex;
   accountHeight?: StringUInt64;
-  accountKey?: AccountKey;
-  entropy?: StringHex;
   firstBlockIndex: StringUInt64;
-  keyDerivationVersion: string;
   mainAddress: StringB58;
   name: string | null;
   nextSubaddressIndex: StringUInt64;
-  object: 'account';
   recoveryMode: boolean;
 }
 

--- a/app/types/PendingSecrets.d.ts
+++ b/app/types/PendingSecrets.d.ts
@@ -1,6 +1,0 @@
-import type { StringHex } from './SpecialStrings';
-
-export type PendingSecrets = {
-  entropy: StringHex;
-  mnemonic: string;
-};

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -6,7 +6,6 @@ import { Confirmation, Confirmations } from './Confirmation';
 import { Contact } from './Contact';
 import { GiftCode } from './GiftCode';
 import { NetworkStatus } from './NetworkStatus';
-import { PendingSecrets } from './PendingSecrets';
 import { ReceiverReceipt, ReceiverReceipts } from './ReceiverReceipt';
 import { SelectedAccount } from './SelectedAccount';
 import { StringB58, StringHex, StringUInt64 } from './SpecialStrings';
@@ -28,7 +27,6 @@ export type {
   Contact,
   GiftCode,
   NetworkStatus,
-  PendingSecrets,
   ReceiverReceipt,
   ReceiverReceipts,
   SelectedAccount,


### PR DESCRIPTION
We should not keep the account secrets in the redux store, for security reasons. This moves all account secrets data off of the account model and out of the redux store. The mnemonic is fetched by the component that renders it and only stored in local state in that component, so that it is purged from memory when that modal closes.

Manually tested:
- viewing the account secrets from settings panel
- viewing account secrets after account creation