### PR TITLE
Improve auto sync

### DIFF
--- a/app/fullService/api/getAccount.ts
+++ b/app/fullService/api/getAccount.ts
@@ -1,5 +1,5 @@
 import { store } from '../../redux/store';
-import type { Account, AccountStatus } from '../../types/Account.d';
+import type { Account, AccountStatus, AccountV2 } from '../../types/Account.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
@@ -13,17 +13,15 @@ type GetAccountResult = {
   account: Account;
 };
 
-export function convertAccountV2(accountStatus: AccountStatus): GetAccountResult {
+export function convertAccountV2(account: AccountV2): Account {
   return {
-    account: {
-      accountHeight: accountStatus.account.nextBlockIndex,
-      accountId: accountStatus.account.id,
-      firstBlockIndex: accountStatus.account.firstBlockIndex,
-      mainAddress: accountStatus.account.mainAddress,
-      name: accountStatus.account.name,
-      nextSubaddressIndex: accountStatus.account.nextSubaddressIndex,
-      recoveryMode: accountStatus.account.recoveryMode,
-    },
+    accountHeight: account.nextBlockIndex,
+    accountId: account.id,
+    firstBlockIndex: account.firstBlockIndex,
+    mainAddress: account.mainAddress,
+    name: account.name,
+    nextSubaddressIndex: account.nextSubaddressIndex,
+    recoveryMode: account.recoveryMode,
   };
 }
 
@@ -62,7 +60,7 @@ const getAccount = async ({ accountId }: GetAccountParams): Promise<GetAccountRe
   } else if (!result) {
     throw new Error('Failure to retrieve data.');
   } else {
-    return convertAccountV2(result);
+    return { account: convertAccountV2(result.account) };
   }
 };
 

--- a/app/fullService/api/getAllAccounts.ts
+++ b/app/fullService/api/getAllAccounts.ts
@@ -1,6 +1,6 @@
 import type { Accounts, Account, AccountsV2 } from '../../types/Account.d';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
-import getAccount from './getAccount';
+import { convertAccountV2 } from './getAccount';
 
 const GET_ALL_ACCOUNTS_METHOD = 'get_accounts';
 
@@ -23,13 +23,12 @@ export const getAllAccountsV2 = async (): Promise<AccountsV2> => {
 const getAllAccounts = async (): Promise<GetAllAccountsResult> => {
   const result = await getAllAccountsV2();
 
-  const processedAccounts: { [accountId: string]: Account } = {};
-
-  await Promise.all(
-    Object.values(result.accountIds).map(async (accountId: string) => {
-      const processedAccount = await getAccount({ accountId });
-      processedAccounts[accountId] = processedAccount.account;
-    })
+  const processedAccounts = result.accountIds.reduce(
+    (accum: { [accountId: string]: Account }, id) => ({
+      ...accum,
+      [id]: convertAccountV2(result.accountMap[id]),
+    }),
+    {}
   );
 
   return {

--- a/app/fullService/api/getWalletStatus.ts
+++ b/app/fullService/api/getWalletStatus.ts
@@ -1,8 +1,6 @@
 import { TOKENS } from '../../constants/tokens';
-import type { Accounts } from '../../types/Account.d';
 import type { WalletStatusV2, WalletStatus } from '../../types/WalletStatus.d';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
-import getAllAccounts from './getAllAccounts';
 
 const GET_WALLET_STATUS_METHOD = 'get_wallet_status';
 
@@ -10,14 +8,9 @@ type GetWalletStatusResult = {
   walletStatus: WalletStatus;
 };
 
-function convertWalletStatusFromV2(
-  status: WalletStatusV2,
-  accounts: Accounts
-): GetWalletStatusResult {
+function convertWalletStatusFromV2(status: WalletStatusV2): GetWalletStatusResult {
   return {
     walletStatus: {
-      accountIds: accounts.accountIds,
-      accountMap: accounts.accountMap,
       balancePerToken: {
         [TOKENS.MOB.id]: {
           orphanedPmob: status.balancePerToken[TOKENS.MOB.id]?.orphaned || '0',
@@ -38,7 +31,6 @@ function convertWalletStatusFromV2(
       localBlockHeight: status.localBlockHeight,
       minSyncedBlockIndex: status.minSyncedBlockIndex,
       networkBlockHeight: status.networkBlockHeight,
-      object: 'wallet_status',
     },
   };
 }
@@ -47,14 +39,12 @@ const getWalletStatus = async (): Promise<GetWalletStatusResult> => {
   const { result, error }: AxiosFullServiceResponse<{ walletStatus: WalletStatusV2 }> =
     await axiosFullService(GET_WALLET_STATUS_METHOD, null);
 
-  const accounts = await getAllAccounts();
-
   if (error) {
     throw new Error(error);
   } else if (!result) {
     throw new Error('Failure to retrieve data.');
   } else {
-    return convertWalletStatusFromV2(result.walletStatus, accounts);
+    return convertWalletStatusFromV2(result.walletStatus);
   }
 };
 

--- a/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
+++ b/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
@@ -10,6 +10,7 @@ import { Redirect } from 'react-router-dom';
 import { SplashScreen } from '../../../components/SplashScreen';
 import LogoIcon from '../../../components/icons/LogoIcon';
 import routePaths from '../../../constants/routePaths';
+import { getAllAccounts } from '../../../fullService/api';
 import { initialReduxStoreState, ReduxStoreState } from '../../../redux/reducers/reducers';
 import {
   addAccount,
@@ -61,7 +62,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const untilFullServiceRuns = async () => {
   for (let i = 0; i < 25; i++) {
     try {
-      await getWalletStatus();
+      await getAllAccounts();
       return true;
     } catch (e) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -89,9 +90,9 @@ export const AuthPage: FC = (): JSX.Element => {
     const controller = new AbortController();
     (async () => {
       try {
-        const status = await getWalletStatus();
-        setAccountIds(status.accountIds);
-        if (status.accountIds?.length) {
+        const accounts = await getAllAccounts();
+        setAccountIds(accounts.accountIds);
+        if (accounts.accountIds?.length) {
           confirmEntropyKnown();
         }
 
@@ -135,11 +136,11 @@ export const AuthPage: FC = (): JSX.Element => {
         try {
           await ipcRenderer.invoke('start-full-service', password, null, startInOfflineMode);
           await untilFullServiceRuns();
-          const status = await getWalletStatus();
-          setAccountIds(status.accountIds);
+          const accounts = await getAllAccounts();
+          setAccountIds(accounts.accountIds);
           await unlockWallet(password, startInOfflineMode);
-          if (status.accountIds?.length) {
-            await selectAccount(status.accountIds[0]);
+          if (accounts.accountIds?.length) {
+            await selectAccount(accounts.accountIds[0]);
           }
           setFullServiceIsRunning(true);
         } catch (err) {
@@ -168,10 +169,10 @@ export const AuthPage: FC = (): JSX.Element => {
       try {
         await ipcRenderer.invoke('start-full-service', password, null, startInOfflineMode);
         await untilFullServiceRuns();
-        const status = await getWalletStatus();
+        const accounts = await getAllAccounts();
         await createWallet(password);
         await unlockWallet(password, startInOfflineMode);
-        setAccountIds(status.accountIds);
+        setAccountIds(accounts.accountIds);
         setWalletDbExists(true);
         setFullServiceIsRunning(true);
       } catch (err) {
@@ -195,11 +196,12 @@ export const AuthPage: FC = (): JSX.Element => {
     confirmEntropyKnown();
     try {
       const status = await getWalletStatus();
+      const accounts = await getAllAccounts();
       await unlockWallet(password, status.networkBlockHeight === '0');
-      if (status?.accountIds?.length) {
-        await selectAccount(status.accountIds[0]);
+      if (accounts?.accountIds?.length) {
+        await selectAccount(accounts.accountIds[0]);
       }
-      setAccountIds(status?.accountIds ?? []);
+      setAccountIds(accounts?.accountIds ?? []);
     } catch (err) {
       console.log(err); // eslint-disable-line no-console
     }

--- a/app/redux/actions/updateStatusAction.ts
+++ b/app/redux/actions/updateStatusAction.ts
@@ -1,26 +1,23 @@
-import { Account, BalanceStatus, SelectedAccount, WalletStatus } from '../../types';
+import { Account, BalanceStatus, SelectedAccount } from '../../types';
 
 export const UPDATE_WALLET_STATUS = 'UPDATE_WALLET_STATUS';
 
 export type UpdateStatusAction = {
   payload: {
     selectedAccount: SelectedAccount;
-    walletStatus: WalletStatus;
   };
   type: 'UPDATE_WALLET_STATUS';
 };
 
 export const updateStatusAction = (
   account: Account,
-  balanceStatus: BalanceStatus,
-  walletStatus: WalletStatus
+  balanceStatus: BalanceStatus
 ): UpdateStatusAction => ({
   payload: {
     selectedAccount: {
       account,
       balanceStatus,
     },
-    walletStatus,
   },
   type: 'UPDATE_WALLET_STATUS',
 });

--- a/app/redux/reducers/reducers.ts
+++ b/app/redux/reducers/reducers.ts
@@ -126,8 +126,6 @@ export const initialReduxStoreState: ReduxStoreState = {
   transactionLogs: null,
   txos: { txoIds: [], txoMap: {} },
   walletStatus: {
-    accountIds: [],
-    accountMap: {},
     balancePerToken: {
       [TOKENS.MOB.id]: {
         orphanedPmob: '',

--- a/app/redux/reducers/reducers.ts
+++ b/app/redux/reducers/reducers.ts
@@ -335,14 +335,12 @@ export const reducer = (
     }
 
     case UPDATE_WALLET_STATUS: {
-      const { selectedAccount, walletStatus } = (action as UpdateStatusAction).payload;
-      return sameObject(selectedAccount, state.selectedAccount) &&
-        sameObject(walletStatus, state.walletStatus)
+      const { selectedAccount } = (action as UpdateStatusAction).payload;
+      return sameObject(selectedAccount, state.selectedAccount)
         ? state
         : {
             ...state,
             selectedAccount,
-            walletStatus,
           };
     }
 

--- a/app/redux/services/unlockWallet.ts
+++ b/app/redux/services/unlockWallet.ts
@@ -1,6 +1,5 @@
 import * as fullServiceApi from '../../fullService/api';
 import { decryptContacts } from '../../services';
-import { Accounts } from '../../types';
 import * as localStore from '../../utils/LocalStore';
 import { validatePassphrase } from '../../utils/authentication';
 import { decrypt } from '../../utils/encryption';
@@ -20,16 +19,12 @@ export const unlockWallet = async (password: string, startInOfflineMode = false)
   const contacts = await decryptContacts(secretKey);
 
   const { walletStatus } = await fullServiceApi.getWalletStatus();
+  const accounts = await fullServiceApi.getAllAccounts();
 
   await getFees();
 
-  const accounts: Accounts = {
-    accountIds: walletStatus.accountIds ?? [],
-    accountMap: walletStatus.accountMap ?? {},
-  };
-
-  const firstAccountId = (walletStatus.accountIds ?? [])[0];
-  const firstAccount = firstAccountId && (walletStatus.accountMap ?? {})[firstAccountId];
+  const firstAccountId = (accounts.accountIds ?? [])[0];
+  const firstAccount = firstAccountId && (accounts.accountMap ?? {})[firstAccountId];
 
   let { selectedAccount, addingAccount } = initialReduxStoreState;
   // if an account already exists, use the default to the first account available. Otherwise, use the initial state

--- a/app/redux/services/updateStatus.ts
+++ b/app/redux/services/updateStatus.ts
@@ -5,6 +5,5 @@ import { store } from '../store';
 
 export const updateStatus = async (accountId: string, account: Account): Promise<void> => {
   const { balance: balanceStatus } = await fullServiceApi.getBalanceForAccount({ accountId });
-  const { walletStatus } = await fullServiceApi.getWalletStatus();
-  store.dispatch(updateStatusAction(account, balanceStatus, walletStatus));
+  store.dispatch(updateStatusAction(account, balanceStatus));
 };

--- a/app/types/WalletStatus.d.ts
+++ b/app/types/WalletStatus.d.ts
@@ -1,5 +1,4 @@
-import type { Account } from './Account.d';
-import type { StringHex, StringUInt64 } from './SpecialStrings';
+import type { StringUInt64 } from './SpecialStrings';
 
 type Balance = {
   orphanedPmob: StringUInt64;
@@ -10,13 +9,10 @@ type Balance = {
 };
 
 export interface WalletStatus {
-  accountIds?: StringHex[];
-  accountMap?: { [accountId: string]: Account };
   isSyncedAll: boolean;
   localBlockHeight?: StringUInt64;
   minSyncedBlockIndex: StringUInt64;
   networkBlockHeight?: StringUInt64;
-  object?: 'wallet_status';
   balancePerToken: Record<number, Balance>;
 }
 


### PR DESCRIPTION
In order to reduce the number of API calls needed to sync accounts:
- remove account map from wallet status. This field is no longer included in the full service wallet status response.
- In places where the app used the `walletstatus.accountMap`, replace it with the accountMap at the root level of the redux store or a call to `getAllAccounts`.
- Remove wallet status update from auto-sync loop. It doesn't contain any data we need to update.

Tested to make sure that each update is only fetching data for the selected account and that it's not making any nested loop calls.

manually tested account creation, import, deletion, transaction and auto-sync behavior.