### PR TITLE
Fix wallet status update

### DIFF
--- a/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
+++ b/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
@@ -65,6 +65,7 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
   const token = useCurrentToken();
   const { t } = useTranslation('BalanceIndicator');
   const { walletStatus } = useSelector((state: ReduxStoreState) => state);
+  console.log(walletStatus);
   // Look at all balance values in wallet for eUSD token. If any > 0, wallet has access to eUSD
   const walletHasEUSD = Boolean(
     Object.values(walletStatus.balancePerToken[TOKENS.EUSD.id]).filter((value) => Number(value) > 0)

--- a/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
+++ b/app/layouts/DashboardLayout/BalanceIndicator.view/BalanceIndicator.view.tsx
@@ -65,7 +65,6 @@ const BalanceIndicator: FC<BalanceIndicatorProps> = ({
   const token = useCurrentToken();
   const { t } = useTranslation('BalanceIndicator');
   const { walletStatus } = useSelector((state: ReduxStoreState) => state);
-  console.log(walletStatus);
   // Look at all balance values in wallet for eUSD token. If any > 0, wallet has access to eUSD
   const walletHasEUSD = Boolean(
     Object.values(walletStatus.balancePerToken[TOKENS.EUSD.id]).filter((value) => Number(value) > 0)

--- a/app/redux/actions/selectAccountAction.ts
+++ b/app/redux/actions/selectAccountAction.ts
@@ -1,4 +1,4 @@
-import { Accounts, Addresses, SelectedAccount } from '../../types';
+import { Accounts, Addresses, SelectedAccount, WalletStatus } from '../../types';
 
 export const SELECT_ACCOUNT = 'SELECT_ACCOUNT';
 
@@ -8,18 +8,21 @@ export type SelectAccountAction = {
     accounts: Accounts;
     addresses: Addresses;
     selectedAccount: SelectedAccount;
+    walletStatus: WalletStatus;
   };
 };
 
 export const selectAccountAction = (
   accounts: Accounts,
   addresses: Addresses,
-  selectedAccount: SelectedAccount
+  selectedAccount: SelectedAccount,
+  walletStatus: WalletStatus
 ): SelectAccountAction => ({
   payload: {
     accounts,
     addresses,
     selectedAccount,
+    walletStatus,
   },
   type: SELECT_ACCOUNT,
 });

--- a/app/redux/reducers/reducers.ts
+++ b/app/redux/reducers/reducers.ts
@@ -264,7 +264,8 @@ export const reducer = (
     }
 
     case SELECT_ACCOUNT: {
-      const { accounts, addresses, selectedAccount } = (action as SelectAccountAction).payload;
+      const { accounts, addresses, selectedAccount, walletStatus } = (action as SelectAccountAction)
+        .payload;
       return {
         ...state,
         accounts,
@@ -272,6 +273,7 @@ export const reducer = (
         addresses,
         isEntropyKnown: true,
         selectedAccount,
+        walletStatus,
       };
     }
 

--- a/app/redux/services/selectAccount.ts
+++ b/app/redux/services/selectAccount.ts
@@ -1,4 +1,5 @@
 import * as fullServiceApi from '../../fullService/api';
+import { getWalletStatus } from '../../services';
 import { Accounts, Addresses, SelectedAccount } from '../../types';
 import { errorToString } from '../../utils/errorHandler';
 import { selectAccountAction } from '../actions';
@@ -14,6 +15,7 @@ export const selectAccount = async (accountId: string): Promise<void> => {
     const p3 = fullServiceApi.getBalanceForAccount({ accountId });
     const p4 = getAllTransactionLogsForAccount(accountId);
     const p5 = getAllTxosForAccount(accountId);
+    const walletStatus = await getWalletStatus();
 
     const { account } = await p1;
     const { addressIds, addressMap } = await p2;
@@ -25,7 +27,7 @@ export const selectAccount = async (accountId: string): Promise<void> => {
     const addresses: Addresses = { addressIds, addressMap };
     const selectedAccount: SelectedAccount = { account, balanceStatus };
 
-    store.dispatch(selectAccountAction(accounts, addresses, selectedAccount));
+    store.dispatch(selectAccountAction(accounts, addresses, selectedAccount, walletStatus));
   } catch (err) {
     const errorMessage = errorToString(err);
     throw new Error(errorMessage);


### PR DESCRIPTION
Recent PRs removed the wallet status update from a few queries, including the auto-sync. This caused a bug where the wallet status could be out of sync after importing an account to a wallet, which resulted in eUSD options not rendering until the app was restarted. This fix adds a wallet status update to selectAccount, to ensure that the wallet status is always up to date when changing accounts.