### PR TITLE
Fix offline mode

### DIFF
--- a/app/fullService/api/buildTransaction.ts
+++ b/app/fullService/api/buildTransaction.ts
@@ -13,6 +13,7 @@ export type BuildTransactionParams = {
   inputTxoIds?: StringHex[];
   maxSpendableValue?: StringUInt64;
   tombstoneBlock?: StringUInt64;
+  blockVersion?: StringUInt64;
 };
 
 export type AddressAndAmount = [StringB58, TransactionAmount];
@@ -40,11 +41,13 @@ const buildTransaction = async ({
   inputTxoIds,
   maxSpendableValue,
   tombstoneBlock,
+  blockVersion,
 }: BuildTransactionParams): Promise<BuildTransactionResult> => {
   const { result, error }: AxiosFullServiceResponse<BuilTransactionProposalResponse> =
     await axiosFullService(BUILD_TRANSACTION_METHOD, {
       accountId,
       addressesAndAmounts,
+      blockVersion,
       feeTokenId,
       feeValue,
       inputTxoIds,

--- a/app/fullService/api/getNetworkStatus.ts
+++ b/app/fullService/api/getNetworkStatus.ts
@@ -3,6 +3,9 @@ import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService'
 
 const GET_NETWORK_STATUS_METHOD = 'get_network_status';
 
+// ideally this would be fetched from the network, but FS can't know current bloc version in offline mode
+export const BLOCK_VERSION = '2';
+
 type GetNetworkStatusResult = {
   networkStatus: NetworkStatus;
 };

--- a/app/fullService/api/submitTransaction.ts
+++ b/app/fullService/api/submitTransaction.ts
@@ -9,6 +9,7 @@ const SUBMIT_TRANSACTION_METHOD = 'submit_transaction';
 type SubmitTransactionParams = {
   accountId?: StringHex;
   txProposal: TxProposal;
+  blockVersion?: string;
 };
 
 type SubmitTransactionResult = {
@@ -18,10 +19,12 @@ type SubmitTransactionResult = {
 const submitTransaction = async ({
   accountId,
   txProposal,
+  blockVersion,
 }: SubmitTransactionParams): Promise<SubmitTransactionResult> => {
   const { result, error }: AxiosFullServiceResponse<{ transactionLog: TransactionLogV2 }> =
     await axiosFullService(SUBMIT_TRANSACTION_METHOD, {
       accountId,
+      blockVersion,
       txProposal,
     });
 

--- a/app/pages/SendReceive/SendMob.view/SendMob.view.tsx
+++ b/app/pages/SendReceive/SendMob.view/SendMob.view.tsx
@@ -155,7 +155,6 @@ const SendMob: FC<SendMobProps> = ({
   const handleConfirmSubmit = (resetForm: () => void) => onClickConfirm(resetForm);
 
   const validateAmount = (selectedBalance: bigint, txFee: bigint) => (valueString: string) => {
-    console.log(`feeAmount in validate: ${txFee}`);
     let error;
     const valueAsPicoMob = BigInt(valueString.replace('.', ''));
     if (valueAsPicoMob + txFee > selectedBalance) {

--- a/app/redux/actions/getFeesAction.ts
+++ b/app/redux/actions/getFeesAction.ts
@@ -4,7 +4,7 @@ export const GET_FEE_PMOB = 'GET_FEES';
 
 export type GetFeesAction = {
   type: 'GET_FEES';
-  payload: { fees: Fees };
+  payload: { fees: Fees; blockVersion: string };
 };
 
 export const getFeesAction = (fees: Fees): GetFeesAction => ({

--- a/app/services/submitTransaction.service.ts
+++ b/app/services/submitTransaction.service.ts
@@ -1,40 +1,16 @@
 import * as fullServiceApi from '../fullService/api';
-import { store } from '../redux/store';
 import type { TxProposal } from '../types/TxProposal.d';
 
 const submitTransaction = async (
   txProposal: TxProposal,
-  includeAccountId = true
+  accountId?: string,
+  blockVersion?: string
 ): Promise<void> => {
-  const { selectedAccount } = store.getState();
-  const accountId = includeAccountId ? selectedAccount.account.accountId : undefined;
-  // submit transaction
-  // TODO probably want to figure out what I want to save about this transaction log
   await fullServiceApi.submitTransaction({
     accountId,
+    blockVersion,
     txProposal,
   });
-
-  // TODO- right now, we're just using the selected account to refresh
-  // this is obviously not ideal
-  // const { balance: balanceStatus } = await fullServiceApi.getBalanceForAccount({ accountId });
-  // const { walletStatus } = await fullServiceApi.getWalletStatus();
-
-  // FIX-ME: Currently, Full-Service does not seperate pending change and pending outgoing.
-  // We will need Full-Service to clearly seperate these values for us to properly show pending.
-  // Until we have that, the balance may dip as long as the UTXO spent on the transaction before
-  // bouncing back up.
-  // Alternately, we can just make balance equal to balance + pending (for now)
-  // dispatch({
-  //   payload: {
-  //     selectedAccount: {
-  //       account: selectedAccount.account,
-  //       balanceStatus,
-  //     },
-  //     walletStatus,
-  //   },
-  //   type: 'UPDATE_WALLET_STATUS',
-  // });
 };
 
 export default submitTransaction;

--- a/full-service-bin/mainnet/start-full-service-offline.sh
+++ b/full-service-bin/mainnet/start-full-service-offline.sh
@@ -16,11 +16,14 @@ killall full-service || true
 LEDGER_DB_DIR="$1"
 WALLET_DB_DIR="$2"
 WALLET_DB_FILE="$3"
+MC_API_KEY="$4"
 
 mkdir -p "${LEDGER_DB_DIR}"
 mkdir -p "${WALLET_DB_DIR}"
 
 echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}" > /tmp/mylog
+
+export MC_API_KEY=${MC_API_KEY}
 
 RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \

--- a/full-service-bin/testnet/start-full-service-offline.sh
+++ b/full-service-bin/testnet/start-full-service-offline.sh
@@ -16,11 +16,14 @@ killall full-service || true
 LEDGER_DB_DIR="$1"
 WALLET_DB_DIR="$2"
 WALLET_DB_FILE="$3"
+MC_API_KEY="$4"
 
 mkdir -p "${LEDGER_DB_DIR}"
 mkdir -p "${WALLET_DB_DIR}"
 
 echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}" > /tmp/mylog
+
+export MC_API_KEY=${MC_API_KEY}
 
 RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \


### PR DESCRIPTION
Offline mode is broken in DW 1.6.x and it will not work as-is with 1.7/full-service 2. This fixes that.

- send `block_version` to full-service for building & submitting transactions when offline, so it can sign the tx properly.
- treat wallet as 'synced' when offline mode is enabled, so that users can build transactions