### PR TITLE
Improve error handling

### DIFF
--- a/app/fullService/api/buildTransaction.ts
+++ b/app/fullService/api/buildTransaction.ts
@@ -1,5 +1,5 @@
 import type { StringHex, StringB58, StringUInt64 } from '../../types/SpecialStrings.d';
-import type { AddressAndAmount } from '../../types/TransactionLog';
+import type { AddressAndAmount } from '../../types/TransactionAmount';
 import type { OutputTxo, TxProposal } from '../../types/TxProposal';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 

--- a/app/fullService/axiosFullService.ts
+++ b/app/fullService/axiosFullService.ts
@@ -62,9 +62,10 @@ const axiosFullService = async <T>(
       throw new Error(errorMessage);
     }
 
-    // TODO: determine if we need to handle errors here or elsewhere
-    // such as the API or services
-    return camelCaseObjectKeys(response);
+    return {
+      error: response.error ? response.error.data?.details ?? 'unknown full-service error' : null,
+      result: response.result ? camelCaseObjectKeys(response.result) : null,
+    };
   } catch (error) {
     const errorMessage = errorToString(error);
     throw new Error(errorMessage);

--- a/app/fullService/axiosFullService.ts
+++ b/app/fullService/axiosFullService.ts
@@ -62,10 +62,15 @@ const axiosFullService = async <T>(
       throw new Error(errorMessage);
     }
 
-    return {
-      error: response.error ? response.error.data?.details ?? 'unknown full-service error' : null,
-      result: response.result ? camelCaseObjectKeys(response.result) : null,
-    };
+    if (response.result) {
+      return { result: camelCaseObjectKeys(response.result) };
+    }
+
+    if (response.error) {
+      return { error: response.error.data?.details ?? 'unknown full-service error' };
+    }
+
+    return { error: response.error.data?.details ?? 'invalid full-service response' };
   } catch (error) {
     const errorMessage = errorToString(error);
     throw new Error(errorMessage);


### PR DESCRIPTION
There is a problem where the full-service API client returns an object as an error, rather than a string. This causes the error snackbars to render [object, object] for errors from FS. This fixes that issue, ensuring that the API client returns a string on error so that the snackbar renders the error message properly