### PR TITLE
Fix tx log export

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -487,19 +487,15 @@ ipcMain.handle('export-transaction-history', (_event, transactionLogs) => {
     return false;
   }
 
-  if (transactionLogs.transactionLogMap.length === 0) {
+  if (transactionLogs.length === 0) {
     return false;
   }
 
-  const fields = Object.keys(
-    transactionLogs.transactionLogMap[transactionLogs.transactionLogIds[0]]
-  );
+  const fields = Object.keys(transactionLogs[0]);
   const replacer = (key, value) => (value === null ? '' : value);
 
-  let csv = transactionLogs.transactionLogIds.map((txLogId) =>
-    fields
-      .map((field) => JSON.stringify(transactionLogs.transactionLogMap[txLogId][field], replacer))
-      .join('\t')
+  let csv = transactionLogs.map((txLog) =>
+    fields.map((field) => JSON.stringify(txLog[field], replacer)).join('\t')
   );
   csv.unshift(fields.join('\t'));
   csv = csv.join('\r\n');

--- a/app/pages/Settings/SettingsPage.presenter/SettingsPage.presenter.tsx
+++ b/app/pages/Settings/SettingsPage.presenter/SettingsPage.presenter.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../components/icons';
 import routePaths from '../../../constants/routePaths';
 import useFullServiceConfigs from '../../../hooks/useFullServiceConfigs';
+import { useTransactionLogs } from '../../../hooks/useTransactionLogs';
 import { ReduxStoreState } from '../../../redux/reducers/reducers';
 import {
   addAccount,
@@ -60,15 +61,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export const SettingsPage: FC = (): JSX.Element => {
   const classes = useStyles();
-  const {
-    accounts,
-    addingAccount,
-    offlineModeEnabled,
-    pinThresholdPmob,
-    pin,
-    selectedAccount,
-    transactionLogs,
-  } = useSelector((state: ReduxStoreState) => state);
+  const { accounts, addingAccount, offlineModeEnabled, pinThresholdPmob, pin, selectedAccount } =
+    useSelector((state: ReduxStoreState) => state);
+  const transactionLogs = useTransactionLogs();
 
   const [showing, setShowing] = useState(SETTINGS);
   const [entropy, setEntropy] = useState('');


### PR DESCRIPTION
In order to make attaching contacts to transaction more convenient and easier to read, a previous PR refactored TX usage into a custom hook. That hook was used in the history page, but the settings page continued to fetch raw transaction logs from the redux store. The raw tx logs do not have the contacts attached to them, so contacts were not being populated in the tx history export run from the settings page. This PR adds the custom hook to the settings page, so that contacts are present in the tx history export