### PR TITLE
Increase tombstone block for transaction builds in offline and view-only

### DIFF
--- a/app/fullService/api/buildTransaction.ts
+++ b/app/fullService/api/buildTransaction.ts
@@ -3,8 +3,10 @@ import type { AddressAndAmount } from '../../types/TransactionAmount';
 import type { OutputTxo, TxProposal } from '../../types/TxProposal';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 
-// TODO - fix the error handling at this level -- when giving the wrong method, for example
 const BUILD_TRANSACTION_METHOD = 'build_transaction';
+// this value comes from the mobilecoin lib. Ideally it would be exposed by full-service but in
+// the interest of getting things done fast, we're just hard-coding it here for now
+export const MAX_TOMBSTONE_BLOCKS = 20160;
 
 export type BuildTransactionParams = {
   addressesAndAmounts: AddressAndAmount[];

--- a/app/fullService/api/buildUnsignedTransaction.ts
+++ b/app/fullService/api/buildUnsignedTransaction.ts
@@ -1,5 +1,5 @@
 import type { StringHex, StringB58, StringUInt64 } from '../../types/SpecialStrings.d';
-import type { AddressAndAmount } from '../../types/TransactionLog';
+import type { AddressAndAmount } from '../../types/TransactionAmount';
 import type { UnsignedTxProposal } from '../../types/TxProposal';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
 

--- a/app/fullService/api/buildUnsignedTransaction.ts
+++ b/app/fullService/api/buildUnsignedTransaction.ts
@@ -9,6 +9,7 @@ export type BuildUnsignedTransactionParams = {
   accountId: StringHex;
   addressesAndAmounts: AddressAndAmount[];
   feeValue: StringUInt64;
+  tombstoneBlock: StringUInt64;
 };
 
 export type BuildUnsignedTransactionResult = {
@@ -25,12 +26,14 @@ const buildUnsignedTransaction = async ({
   addressesAndAmounts,
   accountId,
   feeValue,
+  tombstoneBlock,
 }: BuildUnsignedTransactionParams): Promise<BuildUnsignedTransactionResult> => {
   const { result, error }: AxiosFullServiceResponse<BuilTransactionProposalResponse> =
     await axiosFullService(BUILD_UNSIGNED_TRANSACTION_METHOD, {
       accountId,
       addressesAndAmounts,
       feeValue,
+      tombstoneBlock,
     });
 
   if (error) {

--- a/app/fullService/api/submitTransaction.ts
+++ b/app/fullService/api/submitTransaction.ts
@@ -20,7 +20,7 @@ const submitTransaction = async ({
   accountId,
   txProposal,
   blockVersion,
-}: SubmitTransactionParams): Promise<SubmitTransactionResult> => {
+}: SubmitTransactionParams): Promise<SubmitTransactionResult | undefined> => {
   const { result, error }: AxiosFullServiceResponse<{ transactionLog: TransactionLogV2 }> =
     await axiosFullService(SUBMIT_TRANSACTION_METHOD, {
       accountId,
@@ -30,10 +30,11 @@ const submitTransaction = async ({
 
   if (error) {
     throw new Error(error);
-  } else if (!result) {
-    throw new Error('Failure to submit transaction.');
-  } else {
+    // submitting a tx created in offline mode will not return a transaction log
+  } else if (result?.transactionLog) {
     return { transactionLog: convertTransactionLogFromV2(result.transactionLog) };
+  } else {
+    return undefined;
   }
 };
 

--- a/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
+++ b/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
@@ -9,6 +9,7 @@ import { useSelector } from 'react-redux';
 import { v4 as uuidv4 } from 'uuid';
 
 import { buildUnsignedTransaction } from '../../../fullService/api';
+import { MAX_TOMBSTONE_BLOCKS } from '../../../fullService/api/buildTransaction';
 import { BuildUnsignedTransactionParams } from '../../../fullService/api/buildUnsignedTransaction';
 import { BLOCK_VERSION } from '../../../fullService/api/getNetworkStatus';
 import { useCurrentToken } from '../../../hooks/useCurrentToken';
@@ -74,7 +75,7 @@ export const SendReceivePage: FC = (): JSX.Element => {
   const networkBlockHeightBigInt = BigInt(selectedAccount.balanceStatus.networkBlockHeight ?? 0);
   const accountBlockHeightBigInt = BigInt(selectedAccount.balanceStatus.accountBlockHeight ?? 0);
   const localBlockHeightBigInt = BigInt(selectedAccount.balanceStatus.localBlockHeight ?? 0);
-  const offlineTombstone = `${Number(localBlockHeightBigInt) + 100}`;
+  const offlineTombstone = `${Number(localBlockHeightBigInt) + MAX_TOMBSTONE_BLOCKS}`;
 
   let isSynced: boolean;
   if (offlineModeEnabled) {
@@ -191,7 +192,7 @@ export const SendReceivePage: FC = (): JSX.Element => {
         addressesAndAmounts: [[recipientPublicAddress, { tokenId: `${token.id}`, value }]],
         blockVersion: offlineModeEnabled ? BLOCK_VERSION : undefined,
         feeValue: fee,
-        tombstoneBlock: offlineModeEnabled ? offlineTombstone : null,
+        tombstoneBlock: offlineModeEnabled ? offlineTombstone : undefined,
       });
 
       if (result === null || result === undefined) {

--- a/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
+++ b/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
@@ -74,6 +74,7 @@ export const SendReceivePage: FC = (): JSX.Element => {
   const networkBlockHeightBigInt = BigInt(selectedAccount.balanceStatus.networkBlockHeight ?? 0);
   const accountBlockHeightBigInt = BigInt(selectedAccount.balanceStatus.accountBlockHeight ?? 0);
   const localBlockHeightBigInt = BigInt(selectedAccount.balanceStatus.localBlockHeight ?? 0);
+  const offlineTombstone = `${Number(localBlockHeightBigInt) + 100}`;
 
   let isSynced: boolean;
   if (offlineModeEnabled) {
@@ -172,6 +173,7 @@ export const SendReceivePage: FC = (): JSX.Element => {
       accountId,
       addressesAndAmounts: [[recipientPublicAddress, { tokenId: `${token.id}`, value }]],
       feeValue: fee,
+      tombstoneBlock: offlineTombstone,
     };
 
     try {
@@ -189,6 +191,7 @@ export const SendReceivePage: FC = (): JSX.Element => {
         addressesAndAmounts: [[recipientPublicAddress, { tokenId: `${token.id}`, value }]],
         blockVersion: offlineModeEnabled ? BLOCK_VERSION : undefined,
         feeValue: fee,
+        tombstoneBlock: offlineModeEnabled ? offlineTombstone : null,
       });
 
       if (result === null || result === undefined) {


### PR DESCRIPTION
Default tombstone provided by full-service is localheight + 10. This is usually not enough time for the user to build the tx, move it to another computer, and submit it. This provides a tombstone_block arg to full service that contains the localheight + MAX_TOMBSTONE_BLOCK const from the mobilecoin lib.