### PR TITLE
Remove api key from command to start full-service

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -81,6 +81,7 @@ const startFullService = (
   const fullServiceBinariesPath = localStore.getFullServiceBinariesPath();
   const fullServiceLedgerDBPath = localStore.getLedgerDbPath();
   const fullServiceWalletDBPath = localStore.getFullServiceDbPath();
+  const apiKey = localStore.getAPIKey();
 
   console.log('Looking for Full Service binary in', fullServiceBinariesPath);
   console.log(`Offline Mode: ${startInOfflineMode}`);
@@ -92,6 +93,7 @@ const startFullService = (
   const options: { [k: string]: { [j: string]: string } } = {
     env: {
       ...process.env,
+      MC_API_KEY: apiKey,
       MC_PASSWORD: password,
     },
   };
@@ -108,7 +110,6 @@ const startFullService = (
       fullServiceLedgerDBPath,
       fullServiceWalletDBPath,
       [fullServiceWalletDBPath, 'wallet.db'].join('/'),
-      localStore.getAPIKey(),
     ],
     options
   );

--- a/full-service-bin/mainnet/start-full-service-offline.sh
+++ b/full-service-bin/mainnet/start-full-service-offline.sh
@@ -16,14 +16,11 @@ killall full-service || true
 LEDGER_DB_DIR="$1"
 WALLET_DB_DIR="$2"
 WALLET_DB_FILE="$3"
-MC_API_KEY="$4"
 
 mkdir -p "${LEDGER_DB_DIR}"
 mkdir -p "${WALLET_DB_DIR}"
 
-echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}" > /tmp/mylog
-
-export MC_API_KEY=${MC_API_KEY}
+echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR}"
 
 RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \

--- a/full-service-bin/mainnet/start-full-service.sh
+++ b/full-service-bin/mainnet/start-full-service.sh
@@ -16,14 +16,11 @@ killall full-service || true
 LEDGER_DB_DIR="$1"
 WALLET_DB_DIR="$2"
 WALLET_DB_FILE="$3"
-MC_API_KEY="$4"
 
 mkdir -p "${LEDGER_DB_DIR}"
 mkdir -p "${WALLET_DB_DIR}"
 
-echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE} and api-key ${MC_API_KEY}" > /tmp/mylog
-
-export MC_API_KEY=${MC_API_KEY}
+echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}"
 
 RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \

--- a/full-service-bin/testnet/start-full-service-offline.sh
+++ b/full-service-bin/testnet/start-full-service-offline.sh
@@ -16,14 +16,11 @@ killall full-service || true
 LEDGER_DB_DIR="$1"
 WALLET_DB_DIR="$2"
 WALLET_DB_FILE="$3"
-MC_API_KEY="$4"
 
 mkdir -p "${LEDGER_DB_DIR}"
 mkdir -p "${WALLET_DB_DIR}"
 
-echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}" > /tmp/mylog
-
-export MC_API_KEY=${MC_API_KEY}
+echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}"
 
 RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \

--- a/full-service-bin/testnet/start-full-service.sh
+++ b/full-service-bin/testnet/start-full-service.sh
@@ -16,14 +16,11 @@ killall full-service || true
 LEDGER_DB_DIR="$1"
 WALLET_DB_DIR="$2"
 WALLET_DB_FILE="$3"
-MC_API_KEY="$4"
 
 mkdir -p "${LEDGER_DB_DIR}"
 mkdir -p "${WALLET_DB_DIR}"
 
-echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE} and api-key ${MC_API_KEY}" > /tmp/mylog
-
-export MC_API_KEY=${MC_API_KEY}
+echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}"
 
 RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \


### PR DESCRIPTION
remove api key from bash history by adding to the the options/bash env instead of providing it in the arguments for starting full-service