### PR TITLE
Improve account selection

### DIFF
--- a/app/components/AccountCard/AccountCard.view.tsx
+++ b/app/components/AccountCard/AccountCard.view.tsx
@@ -5,7 +5,9 @@ import {
   Box,
   Card,
   CardContent,
+  CircularProgress,
   Container,
+  Dialog,
   IconButton,
   MenuItem,
   Select,
@@ -55,6 +57,7 @@ const AccountCard: FC<AccountCardProps> = ({
   ...rest
 }: AccountCardProps) => {
   const [isQRCode, setIsQRCode] = useState(false);
+  const [loading, setLoading] = useState(false);
   const classes = useStyles();
   const { t } = useTranslation('AccountCard');
 
@@ -65,6 +68,13 @@ const AccountCard: FC<AccountCardProps> = ({
 
   const handleToggleClick = () => setIsQRCode(!isQRCode);
 
+  const handleDialogClose = (event, reason) => {
+    // see https://v4.mui.com/api/dialog/
+    if (!reason) {
+      setLoading(false);
+    }
+  };
+
   let headerString = '';
   if (isQRCode) {
     headerString = isGift ? t('giftQR') : t('accountQR');
@@ -72,7 +82,11 @@ const AccountCard: FC<AccountCardProps> = ({
     headerString = isGift ? t('giftHeader') : t('accountHeader');
   }
 
-  const handleAccountSelectChange = (event) => selectAccount(event.target.value);
+  const handleAccountSelectChange = async (event) => {
+    setLoading(true);
+    await selectAccount(event.target.value);
+    setLoading(false);
+  };
 
   return (
     <Container className={classes.container} fixed maxWidth="sm">
@@ -154,6 +168,13 @@ const AccountCard: FC<AccountCardProps> = ({
           </Box>
         </CardContent>
       </Card>
+      <Dialog
+        open={loading}
+        onClose={handleDialogClose}
+        PaperProps={{ style: { background: 'none' } }}
+      >
+        <CircularProgress style={{ height: '72px', width: '72px' }} />
+      </Dialog>
     </Container>
   );
 };

--- a/app/fullService/api/getAccount.ts
+++ b/app/fullService/api/getAccount.ts
@@ -1,7 +1,9 @@
 import { store } from '../../redux/store';
+import { BalanceStatus } from '../../types';
 import type { Account, AccountStatus, AccountV2 } from '../../types/Account.d';
 import type { StringHex } from '../../types/SpecialStrings.d';
 import axiosFullService, { AxiosFullServiceResponse } from '../axiosFullService';
+import { convertBalanceFromV2 } from './getBalanceForAccount';
 
 const GET_ACCOUNT_METHOD = 'get_account_status';
 
@@ -62,6 +64,31 @@ const getAccount = async ({ accountId }: GetAccountParams): Promise<GetAccountRe
     throw new Error('Failure to retrieve data.');
   } else {
     return { account: convertAccountV2(result.account) };
+  }
+};
+
+export const getAccountAndBalance = async ({
+  accountId,
+}: GetAccountParams): Promise<{ account: Account; balance: BalanceStatus }> => {
+  const { result, error }: AxiosFullServiceResponse<AccountStatus> = await axiosFullService(
+    GET_ACCOUNT_METHOD,
+    {
+      accountId,
+    }
+  );
+
+  if (error) {
+    throw new Error(error);
+  } else if (!result) {
+    throw new Error('Failure to retrieve data.');
+  } else {
+    const account = convertAccountV2(result.account);
+    const balance = convertBalanceFromV2(result);
+
+    return {
+      account,
+      balance,
+    };
   }
 };
 

--- a/app/redux/services/selectAccount.ts
+++ b/app/redux/services/selectAccount.ts
@@ -1,4 +1,5 @@
 import * as fullServiceApi from '../../fullService/api';
+import { getAccountAndBalance } from '../../fullService/api/getAccount';
 import { getWalletStatus } from '../../services';
 import { Accounts, Addresses, SelectedAccount } from '../../types';
 import { errorToString } from '../../utils/errorHandler';
@@ -10,16 +11,13 @@ import { getAllTxosForAccount } from './getAllTxosForAccount';
 export const selectAccount = async (accountId: string): Promise<void> => {
   try {
     const { accountIds, accountMap } = store.getState().accounts;
-    const p1 = fullServiceApi.getAccount({ accountId });
     const p2 = fullServiceApi.getAllAddressesForAccount({ accountId });
-    const p3 = fullServiceApi.getBalanceForAccount({ accountId });
     const p4 = getAllTransactionLogsForAccount(accountId);
     const p5 = getAllTxosForAccount(accountId);
     const walletStatus = await getWalletStatus();
+    const { account, balance: balanceStatus } = await getAccountAndBalance({ accountId });
 
-    const { account } = await p1;
     const { addressIds, addressMap } = await p2;
-    const { balance: balanceStatus } = await p3;
     await p4;
     await p5;
     const accounts: Accounts = { accountIds, accountMap };


### PR DESCRIPTION
Due to changes with FS api, we need a few more requests for selecting an account, and two of those requests take longer because FS needs to talk to the MC network to fulfill them.

This PR removes one extra request by creating a new function to return both balance and account status from the same request. It also adds a loading indicator while the account switch is happening