### PR TITLE
Fix missing txo ids

### DIFF
--- a/app/fullService/api/transactionLogVersionConversion.ts
+++ b/app/fullService/api/transactionLogVersionConversion.ts
@@ -36,7 +36,7 @@ export function mapTxoToAbbreviation(txo: InputTxo | OutputTxo): TransactionAbbr
 
   return {
     recipientAddressId: address,
-    txoIdHex: txo.txoIdHex,
+    txoId: txo.txoId,
     valuePmob: txo.amount.value,
   };
 }
@@ -44,7 +44,7 @@ export function mapTxoToAbbreviation(txo: InputTxo | OutputTxo): TransactionAbbr
 export function mapTxoV2ToAbbreviation(txo: TxoV2, address?: string): TransactionAbbreviation {
   return {
     recipientAddressId: address,
-    txoIdHex: txo.id,
+    txoId: txo.id,
     valuePmob: txo.value,
   };
 }
@@ -54,11 +54,10 @@ export function convertTransactionLogFromV2(v2TransactionLog: TransactionLogV2):
   const direction = 'tx_direction_sent';
   // assuming one token type per transaction. safe assumption for now. Will not be at some point in the future
   const tokenId = Number(v2TransactionLog.outputTxos[0].amount.tokenId);
-
   return {
     accountId: v2TransactionLog.accountId,
     address: v2TransactionLog.outputTxos[0].recipientPublicAddressB58,
-    changeTxoIds: v2TransactionLog.changeTxos.map((t) => t.txoIdHex),
+    changeTxoIds: v2TransactionLog.changeTxos.map((t) => t.txoId),
     changeTxos: v2TransactionLog.changeTxos.map((t) => mapTxoToAbbreviation(t)),
     comment: v2TransactionLog.comment,
     contact: undefined,
@@ -67,11 +66,11 @@ export function convertTransactionLogFromV2(v2TransactionLog: TransactionLogV2):
     failureMessage: null,
     fee: v2TransactionLog.feeAmount.value,
     finalizedBlockIndex: v2TransactionLog.finalizedBlockIndex,
-    inputTxoIds: v2TransactionLog.inputTxos.map((t) => t.txoIdHex),
+    inputTxoIds: v2TransactionLog.inputTxos.map((t) => t.txoId),
     inputTxos: v2TransactionLog.inputTxos.map((t) => mapTxoToAbbreviation(t)),
     object: 'transaction_log',
     offsetCount: 0,
-    outputTxoIds: v2TransactionLog.outputTxos.map((t) => t.txoIdHex),
+    outputTxoIds: v2TransactionLog.outputTxos.map((t) => t.txoId),
     outputTxos: v2TransactionLog.outputTxos.map((t) => mapTxoToAbbreviation(t)),
     sentTime: v2TransactionLog.sentTime,
     status: matchStatus(v2TransactionLog.status),

--- a/app/pages/Gifts/BuildGiftPanel.view/BuildGiftPanel.test.tsx
+++ b/app/pages/Gifts/BuildGiftPanel.view/BuildGiftPanel.test.tsx
@@ -20,7 +20,7 @@ const GIFT_CODES = [
       '7kaRstJZ77fNg7mYpr2HPHBvXmFBATvFH2UfVLkC9X3iWLeR1xbkshVDqLZ13zRag7usgyVvVp8dD6JwQJkcmWhX1YTQfHwC5hS6rCqT',
     memo: '',
     object: 'gift_code',
-    txoIdHex: 'db7845b3acc4db4161c770be0b5c10e65989224523e435b0e71a6ce1ab5e03f7',
+    txoId: 'db7845b3acc4db4161c770be0b5c10e65989224523e435b0e71a6ce1ab5e03f7',
     valuePmob: '2003000000000',
   },
   {
@@ -30,7 +30,7 @@ const GIFT_CODES = [
       '3ct94dFPNKwYZ2mBqnaNdVYBTQ6nD8Lu39YyDoqnY2rW1sn3L8gT34vrgkSk5a1roAxbY8fwXLcJFufT8dxuemNoV1h77BEVZX942gAK',
     memo: 'some memo',
     object: 'gift_code',
-    txoIdHex: '2a2c62ff6ad21073a561a4375fdd256a3b60a25a5e2d6524d4e4839d4d2a0d86',
+    txoId: '2a2c62ff6ad21073a561a4375fdd256a3b60a25a5e2d6524d4e4839d4d2a0d86',
     valuePmob: '3003000000000',
   },
 ];

--- a/app/redux/services/getAllTransactionLogsForAccount.ts
+++ b/app/redux/services/getAllTransactionLogsForAccount.ts
@@ -10,9 +10,9 @@ export const getAllTransactionLogsForAccount = async (accountId: StringHex): Pro
 
     transactionLogs.transactionLogIds.forEach((v: StringHex) => {
       const w = transactionLogs.transactionLogMap[v];
-      w.changeTxoIds = w.changeTxos.map((x: TransactionAbbreviation) => x.txoIdHex);
-      w.inputTxoIds = w.inputTxos.map((x: TransactionAbbreviation) => x.txoIdHex);
-      w.outputTxoIds = w.outputTxos.map((x: TransactionAbbreviation) => x.txoIdHex);
+      w.changeTxoIds = w.changeTxos.map((x: TransactionAbbreviation) => x.txoId);
+      w.inputTxoIds = w.inputTxos.map((x: TransactionAbbreviation) => x.txoId);
+      w.outputTxoIds = w.outputTxos.map((x: TransactionAbbreviation) => x.txoId);
 
       w.address = w.outputTxos[0].recipientAddressId || '';
     });

--- a/app/types/TransactionLog.d.ts
+++ b/app/types/TransactionLog.d.ts
@@ -5,7 +5,7 @@ import type { InputTxo, OutputTxo } from './TxProposal';
 
 export interface TransactionAbbreviation {
   recipientAddressId?: StringB58;
-  txoIdHex: StringHex;
+  txoId: StringHex;
   valuePmob: StringUInt64;
 }
 

--- a/app/types/TxProposal.d.ts
+++ b/app/types/TxProposal.d.ts
@@ -15,14 +15,14 @@ type Outlay = {
 };
 
 export type InputTxo = {
-  txoIdHex: string;
+  txoId: string;
   amount: TransactionAmount;
   subaddressIndex: StringUInt64;
   keyImage: string;
 };
 
 export type OutputTxo = {
-  txoIdHex: string;
+  txoId: string;
   amount: TransactionAmount;
   recipientPublicAddressB58: StringB58;
   confirmationNumber: StringUInt64;


### PR DESCRIPTION
full-service changed the id field in txos from `txo_id_hex` to `txo_id` and that change wasn't carried over to DW. This fixes the DW types to accomodate the change. Tested in the history page and tx history export feature