### PR TITLE
Open links in system browser

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -193,7 +193,7 @@ const createWindow = async () => {
     width: 700,
   });
 
-  // open links in system defaulkt browser instead of new electron window
+  // open links in system default browser instead of new electron window
   mainWindow.webContents.on('new-window', (e, url) => {
     e.preventDefault();
     shell.openExternal(url);

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -193,6 +193,12 @@ const createWindow = async () => {
     width: 700,
   });
 
+  // open links in system defaulkt browser instead of new electron window
+  mainWindow.webContents.on('new-window', (e, url) => {
+    e.preventDefault();
+    shell.openExternal(url);
+  });
+
   mainWindow.webContents.session.setPermissionRequestHandler(
     (_webContents, _permission, callback, details) => {
       if (details.mediaTypes?.includes('video')) {

--- a/app/pages/Auth/ImportViewOnlyAccount.view/ImportViewOnlyAccount.view.tsx
+++ b/app/pages/Auth/ImportViewOnlyAccount.view/ImportViewOnlyAccount.view.tsx
@@ -35,10 +35,11 @@ const ImportViewOnlyAccountView: FC = () => {
       </Typography>
       <Typography variant="body2" color="textSecondary" paragraph>
         View only accounts can read transactions, but can not submit transactions or know which
-        transactions have been spent. They are created using your view keys and do not require or
-        save your spend keys.
+        transactions have been spent. They are a way to use mobilecoin without exposing your spend
+        keys to an online computer.
       </Typography>
-      <Typography variant="body2" color="textPrimary" paragraph>
+      <Typography variant="body2" color="textSecondary" paragraph>
+        View only account import files are created with the mobilecoin Transaction Signer.
         <Link
           target="_blank"
           rel="noreferrer"

--- a/app/pages/Auth/ImportViewOnlyAccount.view/ImportViewOnlyAccount.view.tsx
+++ b/app/pages/Auth/ImportViewOnlyAccount.view/ImportViewOnlyAccount.view.tsx
@@ -35,11 +35,11 @@ const ImportViewOnlyAccountView: FC = () => {
       </Typography>
       <Typography variant="body2" color="textSecondary" paragraph>
         View only accounts can read transactions, but can not submit transactions or know which
-        transactions have been spent. They are a way to use mobilecoin without exposing your spend
+        transactions have been spent. They are a way to use MobileCoin without exposing your spend
         keys to an online computer.
       </Typography>
       <Typography variant="body2" color="textSecondary" paragraph>
-        View only account import files are created with the mobilecoin Transaction Signer.
+        View only account import files are created with the MobileCoin Transaction Signer.
         <Link
           target="_blank"
           rel="noreferrer"


### PR DESCRIPTION
Open web links in the system's default browser instead of a new electron window. Update text on import view-only account page to clarify how VO accounts work