### PR TITLE
Show auth errors, increase timeout

### DIFF
--- a/app/components/AccountCard/AccountCard.view.tsx
+++ b/app/components/AccountCard/AccountCard.view.tsx
@@ -5,9 +5,7 @@ import {
   Box,
   Card,
   CardContent,
-  CircularProgress,
   Container,
-  Dialog,
   IconButton,
   MenuItem,
   Select,
@@ -59,7 +57,6 @@ const AccountCard: FC<AccountCardProps> = ({
   ...rest
 }: AccountCardProps) => {
   const [isQRCode, setIsQRCode] = useState(false);
-  const [loading, setLoading] = useState(false);
   const classes = useStyles();
   const { t } = useTranslation('AccountCard');
   const dispatch = useDispatch();

--- a/app/fullService/axiosFullService.ts
+++ b/app/fullService/axiosFullService.ts
@@ -52,7 +52,7 @@ const axiosFullService = async <T>(
         method,
         params: snakeCaseParams,
       },
-      timeout: 10000,
+      timeout: 15000,
     });
     // @ts-ignore override
     if (!response.jsonrpc) {

--- a/app/layouts/DashboardLayout/SyncStatus.view/SyncStatus.test.tsx
+++ b/app/layouts/DashboardLayout/SyncStatus.view/SyncStatus.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import '../../../testUtils/i18nForTests';
 
@@ -37,9 +37,7 @@ describe('SyncStatus', () => {
     render(<SyncStatus selectedAccount={selectedAccount} sendSyncStatus={sendSyncStatus} />);
 
     fireEvent.mouseOver(screen.getByTestId('tooltip-title'));
-    await waitFor(() =>
-      expect(screen.getByText('Please see Admin Panel in Settings.')).toBeInTheDocument()
-    );
+    expect(await screen.findByText('Please see Admin Panel in Settings.')).toBeVisible();
   });
 
   test('SyncStatus renders syncing message when the difference between NetworkBlockIndex and AccountBlockIndex is too large', async () => {
@@ -71,7 +69,7 @@ describe('SyncStatus', () => {
     render(<SyncStatus selectedAccount={selectedAccount} sendSyncStatus={sendSyncStatus} />);
 
     fireEvent.mouseOver(screen.getByTestId('tooltip-title'));
-    await waitFor(() => expect(screen.getByText(/Syncing with the ledger/)).toBeInTheDocument());
+    expect(await screen.findByText(/Syncing with the ledger/)).toBeVisible();
   });
 
   test('SyncStatus renders synced message when the difference between NetworkBlockIndex and AccountBlockIndex is acceptable', async () => {
@@ -103,8 +101,6 @@ describe('SyncStatus', () => {
     render(<SyncStatus selectedAccount={selectedAccount} sendSyncStatus={sendSyncStatus} />);
 
     fireEvent.mouseOver(screen.getByTestId('tooltip-title'));
-    await waitFor(() =>
-      expect(screen.getByText(/100% synced with the ledger/)).toBeInTheDocument()
-    );
+    expect(await screen.findByText(/100% synced with the ledger/)).toBeVisible();
   });
 });

--- a/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
+++ b/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
@@ -27,6 +27,7 @@ import {
 import { getWalletStatus } from '../../../services';
 import type { Theme } from '../../../theme';
 import * as localStore from '../../../utils/LocalStore';
+import { validatePassphrase } from '../../../utils/authentication';
 import { isHex64 } from '../../../utils/bip39Functions';
 import { errorToString } from '../../../utils/errorHandler';
 import { getKeychainAccounts } from '../../../utils/keytarService';
@@ -77,7 +78,7 @@ const untilFullServiceRuns = async () => {
 /* eslint-enable no-await-in-loop */
 
 export const AuthPage: FC = (): JSX.Element => {
-  const { addingAccount, isAuthenticated, selectedAccount } = useSelector(
+  const { addingAccount, isAuthenticated, selectedAccount, encryptedPassword } = useSelector(
     (state: ReduxStoreState) => state
   );
   const classes = useStyles();
@@ -138,6 +139,7 @@ export const AuthPage: FC = (): JSX.Element => {
       const onClickUnlock = async (password: string, startInOfflineMode: boolean) => {
         confirmEntropyKnown();
         try {
+          await validatePassphrase(password, encryptedPassword);
           await ipcRenderer.invoke('start-full-service', password, null, startInOfflineMode);
           await untilFullServiceRuns();
           const accounts = await getAllAccounts();
@@ -201,6 +203,7 @@ export const AuthPage: FC = (): JSX.Element => {
   const onClickUnlockWallet = async (password: string) => {
     confirmEntropyKnown();
     try {
+      await validatePassphrase(password, encryptedPassword);
       const status = await getWalletStatus();
       const accounts = await getAllAccounts();
       await unlockWallet(password, status.networkBlockHeight === '0');

--- a/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
+++ b/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
@@ -28,6 +28,7 @@ import { getWalletStatus } from '../../../services';
 import type { Theme } from '../../../theme';
 import * as localStore from '../../../utils/LocalStore';
 import { isHex64 } from '../../../utils/bip39Functions';
+import { errorToString } from '../../../utils/errorHandler';
 import { getKeychainAccounts } from '../../../utils/keytarService';
 import { CreateAccountView } from '../CreateAccount.view';
 import { CreateWalletView } from '../CreateWallet.view';
@@ -148,7 +149,8 @@ export const AuthPage: FC = (): JSX.Element => {
           }
           setFullServiceIsRunning(true);
         } catch (err) {
-          console.log(err); // eslint-disable-line no-console
+          const errorMessage = errorToString(err);
+          enqueueSnackbar(errorMessage, { variant: 'error' });
         }
       };
 
@@ -180,7 +182,8 @@ export const AuthPage: FC = (): JSX.Element => {
         setWalletDbExists(true);
         setFullServiceIsRunning(true);
       } catch (err) {
-        console.log(err); // eslint-disable-line no-console
+        const errorMessage = errorToString(err);
+        enqueueSnackbar(errorMessage, { variant: 'error' });
       }
     };
 
@@ -207,7 +210,8 @@ export const AuthPage: FC = (): JSX.Element => {
       }
       setAccountIds(accounts?.accountIds ?? []);
     } catch (err) {
-      console.log(err); // eslint-disable-line no-console
+      const errorMessage = errorToString(err);
+      enqueueSnackbar(errorMessage, { variant: 'error' });
     }
   };
 
@@ -234,8 +238,8 @@ export const AuthPage: FC = (): JSX.Element => {
     try {
       await createAccount(accountName);
     } catch (err) {
-      /* TODO: handle error */
-      console.log('ERROR!', err); // eslint-disable-line no-console
+      const errorMessage = errorToString(err);
+      enqueueSnackbar(errorMessage, { variant: 'error' });
     }
   };
 

--- a/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
+++ b/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
@@ -88,7 +88,6 @@ export const AuthPage: FC = (): JSX.Element => {
   const [loading, setLoading] = useState(true);
   const [accountIds, setAccountIds] = useState([]);
   const { enqueueSnackbar } = useSnackbar();
-  const renderPasswordError = (message: string) => enqueueSnackbar(message, { variant: 'error' });
 
   const offlineStart = localStore.getOfflineStart();
   useEffect(() => {
@@ -143,7 +142,7 @@ export const AuthPage: FC = (): JSX.Element => {
           await untilFullServiceRuns();
           const accounts = await getAllAccounts();
           setAccountIds(accounts.accountIds);
-          await unlockWallet(password, startInOfflineMode, renderPasswordError);
+          await unlockWallet(password, startInOfflineMode);
           if (accounts.accountIds?.length) {
             await selectAccount(accounts.accountIds[0]);
           }
@@ -177,7 +176,7 @@ export const AuthPage: FC = (): JSX.Element => {
         await untilFullServiceRuns();
         const accounts = await getAllAccounts();
         await createWallet(password);
-        await unlockWallet(password, startInOfflineMode, renderPasswordError);
+        await unlockWallet(password, startInOfflineMode);
         setAccountIds(accounts.accountIds);
         setWalletDbExists(true);
         setFullServiceIsRunning(true);
@@ -204,7 +203,7 @@ export const AuthPage: FC = (): JSX.Element => {
     try {
       const status = await getWalletStatus();
       const accounts = await getAllAccounts();
-      await unlockWallet(password, status.networkBlockHeight === '0', renderPasswordError);
+      await unlockWallet(password, status.networkBlockHeight === '0');
       if (accounts?.accountIds?.length) {
         await selectAccount(accounts.accountIds[0]);
       }

--- a/app/redux/services/unlockWallet.ts
+++ b/app/redux/services/unlockWallet.ts
@@ -11,17 +11,13 @@ import { initialReduxStoreState } from '../reducers/reducers';
 import { store } from '../store';
 import { getFees } from './getFees';
 
-export const unlockWallet = async (
-  password: string,
-  startInOfflineMode = false,
-  enqueueSnackbar: (message: string) => void
-): Promise<void> => {
+export const unlockWallet = async (password: string, startInOfflineMode = false): Promise<void> => {
   const { encryptedPassword } = store.getState();
   if (encryptedPassword === undefined) {
     throw new Error('encryptedPassword assertion failed');
   }
 
-  const { secretKey } = await validatePassphrase(password, encryptedPassword, enqueueSnackbar);
+  const { secretKey } = await validatePassphrase(password, encryptedPassword);
 
   let contacts = await decryptContacts(secretKey);
   // required for backwards compatibility. pre-1.7 contacts did not have an ID field

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -3,7 +3,7 @@ import React, { FC, Fragment, useEffect } from 'react';
 import { Button, Dialog, CircularProgress } from '@material-ui/core';
 import { ipcRenderer } from 'electron';
 import { useSnackbar } from 'notistack';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Switch, Redirect, Route } from 'react-router-dom';
 
 import { WHITE_LIGHT } from './constants/colors';


### PR DESCRIPTION
If DW encountered an error (other than invalid PW) in auth, it would log to the console but otherwise not give any feedback to the user. This makes it render an error snackbar with the error message.

Also fix a bug where the invalid password snackbar would only render is FS was already running. Validate local password before starting FS.

Also increase the timeout for FS responses from 10s to 15s because at least one user is running into issues with fog resolving in under 10s.

Also fixers a few linting errors