### PR TITLE
towards packaging via gh actions ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,71 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+jobs:
+  # Build desktop wallet
+  build:
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            os: linux
+            ext: AppImage
+            network: mainnet
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            os: mac
+            ext: dmg
+            network: mainnet
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - uses: FranzDiebold/github-env-vars-action@v1.2.1
+
+    - name: Export version tag
+      run: |
+        echo "VERSION=$(git describe --dirty=+ --always --tags)" >> $GITHUB_ENV
+
+    - name: Configure node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: Configure caching
+      uses: actions/cache@v3
+      with:
+        key: desktop-wallet-${{ matrix.os }}-${{ github.run_id }}
+        restore-keys: desktop-wallet-${{ matrix.os }}
+        path: |
+          ./node_modules
+
+    - name: Install dependencies
+      uses: borales/actions-yarn@v4
+      with:
+        cmd: install
+
+    - name: Fetch and link full-service binaries for packaging
+      run: |
+        ./get-full-service.sh -o ${{ matrix.os }} -n ${{ matrix.network }}
+        cp -r ./full-service-bin/${{ matrix.network }}/* ./full-service-bin/
+        ls ./full-service-bin/
+
+    - name: Build and package app
+      uses: borales/actions-yarn@v4
+      with:
+        cmd: package-${{ matrix.os }}
+
+    - name: Upload package artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: mobilecoin-desktop-${{ matrix.target }}-${{ matrix.network }}
+        path: release/*.${{ matrix.ext }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,14 @@ jobs:
             arch: x64
             ext: AppImage
             network: mainnet
+
           - target: x86_64-apple-darwin
             runner: macos-latest
             os: mac
             arch: x64
             ext: dmg
             network: mainnet
+
           - target: aarch64-apple-darwin
             runner: [self-hosted, macOS, ARM64]
             os: mac
@@ -55,6 +57,15 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+
+    - name: Setup python@3.10 for self-hosted runners
+      # required due to issue with node-gyp@0.7 and python@3.11
+      # see: https://stackoverflow.com/questions/74715990/node-gyp-err-invalid-mode-ru-while-trying-to-load-binding-gyp
+      if: ${{ matrix.os == 'mac' && matrix.arch == 'arm64' }}
+      run: |
+        brew install python@3.10
+        python3.10 -m venv .venv
+        echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
     - name: Configure caching
       uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,19 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             os: linux
+            arch: x64
             ext: AppImage
             network: mainnet
           - target: x86_64-apple-darwin
             runner: macos-latest
             os: mac
+            arch: x64
+            ext: dmg
+            network: mainnet
+          - target: aarch64-apple-darwin
+            runner: [self-hosted, macOS, ARM64]
+            os: mac
+            arch: arm64
             ext: dmg
             network: mainnet
 
@@ -63,7 +71,7 @@ jobs:
 
     - name: Fetch and link full-service binaries for packaging
       run: |
-        ./get-full-service.sh -o ${{ matrix.os }} -n ${{ matrix.network }}
+        ./get-full-service.sh -o ${{ matrix.os }} -a ${{ matrix.arch }} -n ${{ matrix.network }}
         cp -r ./full-service-bin/${{ matrix.network }}/* ./full-service-bin/
         ls ./full-service-bin/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,12 @@ jobs:
       with:
         name: mobilecoin-desktop-${{ matrix.target }}-${{ matrix.network }}
         path: release/*.${{ matrix.ext }}
+
+    - name: Create prerelease for tagged versions
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true
+        prerelease: true
+        files: |
+          release/*.${{ matrix.ext }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Build desktop wallet
+  # Build and package desktop wallet
   build:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
+    env:
+      # Set full service version for binary fetch
+      FULL_SERVICE_VERSION: "v2.7.0"
 
     strategy:
       fail-fast: false
@@ -67,7 +70,7 @@ jobs:
         python3.10 -m venv .venv
         echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
-    - name: Configure caching
+    - name: Configure node module caching
       uses: actions/cache@v3
       with:
         key: desktop-wallet-${{ matrix.os }}-${{ github.run_id }}
@@ -75,14 +78,14 @@ jobs:
         path: |
           ./node_modules
 
-    - name: Install dependencies
+    - name: Install node dependencies
       uses: borales/actions-yarn@v4
       with:
         cmd: install
 
     - name: Fetch and link full-service binaries for packaging
       run: |
-        ./get-full-service.sh -o ${{ matrix.os }} -a ${{ matrix.arch }} -n ${{ matrix.network }}
+        ./get-full-service.sh -o ${{ matrix.os }} -a ${{ matrix.arch }} -n ${{ matrix.network }} -v ${{ env.FULL_SERVICE_VERSION }}
         cp -r ./full-service-bin/${{ matrix.network }}/* ./full-service-bin/
         ls ./full-service-bin/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     env:
-      # Set full service version for binary fetch
+      # Pin full service binary version
       FULL_SERVICE_VERSION: "v2.7.0"
 
     strategy:
@@ -31,7 +31,7 @@ jobs:
             network: mainnet
 
           - target: x86_64-apple-darwin
-            runner: macos-latest
+            runner: [self-hosted, macOS, X64]
             os: mac
             arch: x64
             ext: dmg
@@ -64,7 +64,7 @@ jobs:
     - name: Setup python@3.10 for self-hosted runners
       # required due to issue with node-gyp@0.7 and python@3.11
       # see: https://stackoverflow.com/questions/74715990/node-gyp-err-invalid-mode-ru-while-trying-to-load-binding-gyp
-      if: ${{ matrix.os == 'mac' && matrix.arch == 'arm64' }}
+      if: ${{ matrix.os == 'mac' }}
       run: |
         brew install python@3.10
         python3.10 -m venv .venv

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,12 @@ npm-debug.log.*
 
 full-service-bin/*/*.css
 full-service-bin/*/full-service
+full-service-bin/*/transaction-signer
+full-service-bin/*/validator-service
 full-service-bin/*.css
 full-service-bin/full-service
+full-service-bin/transaction-signer
+full-service-bin/validator-service
 full-service-bin/*.sh
+full-service-bin/mirror/
+*.tar.gz

--- a/get-full-service.sh
+++ b/get-full-service.sh
@@ -50,7 +50,7 @@ fi
 
 # Lookup latest release if not specified
 if [ -z ${FS_VERSION} ]; then
-  FS_VERSION=$(wget -q -O- https://api.github.com/repos/mobilecoinofficial/full-service/releases/latest | jq -r '.name')
+  FS_VERSION=$(curl -L https://api.github.com/repos/mobilecoinofficial/full-service/releases/latest | jq -r '.name')
   echo "Resolved latest full-service version: ${FS_VERSION}"
 else
   echo "Using specified full-service version: ${FS_VERSION}"
@@ -87,7 +87,7 @@ mkdir -p $TEMP_DIR
 # Download file
 if [ ! -f "${TEMP_DIR}/${FILE}" ]; then
   echo "Downloading ${BASE_URL}/${FS_VERSION}/${FILE} to ${TEMP_DIR}"
-  wget -qN --show-progress -P $TEMP_DIR "${BASE_URL}/${FS_VERSION}/${FILE}"
+  curl -L "${BASE_URL}/${FS_VERSION}/${FILE}" --output ${TEMP_DIR}/${FILE}
 else
   echo "Using existing ${TEMP_DIR}/${FILE}"
 fi

--- a/get-full-service.sh
+++ b/get-full-service.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Base URL for full-service binary downloads
+BASE_URL="https://github.com/mobilecoinofficial/full-service/releases/download"
+TEMP_DIR=/tmp/full-service
+
+# Setup defaults
+FS_ARCH="X64"
+FS_NET="mainnet"
+
+
+# Parse arguments
+while getopts 'o:v:a:n:h' opt; do
+  case "$opt" in
+    o)
+      FS_OS=${OPTARG}
+      ;;
+    v)
+      FS_VERSION=${OPTARG}
+      ;;
+    a)
+      FS_ARCH=${OPTARG}
+      ;;
+    n)
+      FS_NET=${OPTARG}
+      ;;
+    ?|h)
+      echo "Usage: $(basename $0) [-o OS] [-v VERSION] [-a ARCH] [-n NETWORK]"
+      echo "OS: mac|linux|win"
+      echo "ARCH: X64|ARM64"
+      echo "NETWORK: mainnet|testnet"
+      exit 1
+      ;;
+  esac
+done
+
+# Resolve OS if not specified
+if [ -z ${FS_OS} ]; then
+  echo "Inferring OS from $OSTYPE"
+
+  if [ "${OSTYPE}" == "linux-gnu" ]; then
+    FS_OS="linux"
+  elif [ "$OSTYPE" == "darwin"* ]; then
+    FS_OS="mac"
+  else
+    echo "Unable to resolve OS type, please use '-o OS'"
+    exit 2
+  fi
+fi
+
+# Lookup latest release if not specified
+if [ -z ${FS_VERSION} ]; then
+  FS_VERSION=$(wget -q -O- https://api.github.com/repos/mobilecoinofficial/full-service/releases/latest | jq -r '.name')
+  echo "Resolved latest full-service version: ${FS_VERSION}"
+else
+  echo "Using specified full-service version: ${FS_VERSION}"
+fi
+
+echo "Fetching ${FS_VERSION} binaries for ${FS_OS}-${FS_ARCH}-${FS_NET}"
+
+# Compute download URLs
+case $FS_OS in
+  mac)
+    echo "Fetching macOS ${FS_NET} binaries"
+    FILE="MobileCoin-${FS_VERSION}-macOS-${FS_ARCH}-${FS_NET}.tar.gz"
+    ;;
+
+  linux)
+    echo "Fetching linux ${FS_NET} binaries"
+    FILE="MobileCoin-${FS_VERSION}-Linux-${FS_ARCH}-${FS_NET}.tar.gz"
+    ;;
+
+  win)
+    echo "Windows not (yet?) supported"
+    exit 1
+    ;;
+
+  *)
+    echo "Unrecognised OS ${FS_OS}"
+    exit 2
+    ;;
+esac
+
+# Setup temporary directory
+mkdir -p $TEMP_DIR
+
+# Download file
+if [ ! -f "${TEMP_DIR}/${FILE}" ]; then
+  echo "Downloading ${BASE_URL}/${FS_VERSION}/${FILE} to ${TEMP_DIR}"
+  wget -qN --show-progress -P $TEMP_DIR "${BASE_URL}/${FS_VERSION}/${FILE}"
+else
+  echo "Using existing ${TEMP_DIR}/${FILE}"
+fi
+
+# Unpack to binary directory
+echo "Extracting ${FILE} to ./full-service-bin/${FS_NET}"
+tar -xf ${TEMP_DIR}/${FILE} --strip-components=1 -C ./full-service-bin/${FS_NET}


### PR DESCRIPTION
a first step toward automating desktop-wallet packaging and releases via CI

- adds gh actions packaging, initially enabled for macos x64/aarch64 and linux x64
- adds `get-full-service.sh` helper script for pulling full-service binaries via github releases
- pins CI build full-service version via `FULL_SERVICE_VERSION` variable in the workflow

replaces #301

cc. @briancorbin 