### PR TITLE
Add link to full-service logs path

### DIFF
--- a/app/pages/Settings/FullServiceDirectory.view/FullServiceDirectory.view.tsx
+++ b/app/pages/Settings/FullServiceDirectory.view/FullServiceDirectory.view.tsx
@@ -57,7 +57,7 @@ const FullServiceDirectory: FC<FullServiceDirectoryProps> = ({
         </div>
         <Box py={1} />
         <Typography variant="body2" color="textPrimary">
-          Full-Serice logs path
+          {t('logsPath')}
         </Typography>
         <div style={{ cursor: 'pointer' }}>
           <Typography

--- a/app/pages/Settings/FullServiceDirectory.view/FullServiceDirectory.view.tsx
+++ b/app/pages/Settings/FullServiceDirectory.view/FullServiceDirectory.view.tsx
@@ -55,6 +55,19 @@ const FullServiceDirectory: FC<FullServiceDirectoryProps> = ({
             {`${fullServiceBinariesPath}`}
           </Typography>
         </div>
+        <Box py={1} />
+        <Typography variant="body2" color="textPrimary">
+          Full-Serice logs path
+        </Typography>
+        <div style={{ cursor: 'pointer' }}>
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            onClick={() => ipcRenderer.send('view-path', '/tmp')}
+          >
+            /tmp
+          </Typography>
+        </div>
       </Box>
     </Box>
   );

--- a/locales/enUS/translation.json
+++ b/locales/enUS/translation.json
@@ -410,7 +410,8 @@
     "importLedgerDb": "Import",
     "ledgerDbPathHeader": "Ledger Database Path:",
     "fullServiceDbPathHeader": "Full-Service Database Path:",
-    "fullServiceBinariesPathHeader": "Full-Service Binaries Path:"
+    "fullServiceBinariesPathHeader": "Full-Service Binaries Path:",
+    "logsPath": "Full-Serice Logs Path"
   },
   "NavBar": {
     "contacts": "Contacts",

--- a/locales/upDEV/translation.json
+++ b/locales/upDEV/translation.json
@@ -372,7 +372,7 @@
     "formLabel": "FULL-SERVICE DIRECTORY",
     "ledgerDbPathHeader": "LEDGER DATABASE PATH:",
     "fullServiceDbPathHeader": "FULL-SERVICE DATABASE PATH:",
-    "logsPath": "Full-Serice Logs Path"
+    "logsPath": "FULL_SERVICE LOGS PATH"
   },
   "NavBar": {
     "contacts": "CONTACTS",

--- a/locales/upDEV/translation.json
+++ b/locales/upDEV/translation.json
@@ -371,7 +371,8 @@
     "exportTransactionHistory": "EXPORT TX HISTORY",
     "formLabel": "FULL-SERVICE DIRECTORY",
     "ledgerDbPathHeader": "LEDGER DATABASE PATH:",
-    "fullServiceDbPathHeader": "FULL-SERVICE DATABASE PATH:"
+    "fullServiceDbPathHeader": "FULL-SERVICE DATABASE PATH:",
+    "logsPath": "Full-Serice Logs Path"
   },
   "NavBar": {
     "contacts": "CONTACTS",

--- a/locales/zhCN/translation.json
+++ b/locales/zhCN/translation.json
@@ -350,7 +350,8 @@
     "exportTransactionHistory": "Export Tx History",
     "formLabel": "MobileCoin 守护进程目录",
     "ledgerDbPathHeader": "账簿数据库路径：",
-    "fullServiceDbPathHeader": "MobileCoin 守护进程数据库路径："
+    "fullServiceDbPathHeader": "MobileCoin 守护进程数据库路径：",
+    "logsPath": "Full-Serice Logs Path"
   },
   "NavBar": {
     "contacts": "通讯录",


### PR DESCRIPTION
make it easier for users to find & send logs for debugging by providing a link that opens the folder containing the FS logs