### PR TITLE
Update transaction log filter

### DIFF
--- a/app/fullService/api/transactionLogVersionConversion.ts
+++ b/app/fullService/api/transactionLogVersionConversion.ts
@@ -88,7 +88,7 @@ export function convertTransactionLogsResponseFromV2(
   const filteredLogids: string[] = [];
   const filteredConvertedLogMap: { [transactionLogId: string]: TransactionLog } = {};
   Object.entries(transactionlogs.transactionLogMap).forEach(([id, log]) => {
-    if (log.finalizedBlockIndex) {
+    if (log.submittedBlockIndex) {
       filteredLogids.push(id);
       filteredConvertedLogMap[id] = convertTransactionLogFromV2(log);
     }


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

There are transactions shown in the transaction history for cancelled transactions. PR #312 addressed some of these but not all of them

### In this PR

PR #312 filters making sure that `finalizedBlockIndex` is set, but full-service sometimes sets that even though it does not submit the block. This PR switches the filter to make sure that `submittedBlockIndex` is set instead.