### PR TITLE
Fix saving contacts

### DIFF
--- a/app/pages/Contacts/ContactForm.view/ContactForm.d.ts
+++ b/app/pages/Contacts/ContactForm.view/ContactForm.d.ts
@@ -8,6 +8,7 @@ export interface ContactFormProps {
   id?: string;
   isFavorite?: boolean;
   recipientAddress?: string;
+  isNew?: boolean;
   onClickCancel: () => void;
   onClickDelete?: () => void;
   onClickSaved: (x: Contact) => void;

--- a/app/pages/Contacts/ContactForm.view/ContactForm.test.tsx
+++ b/app/pages/Contacts/ContactForm.view/ContactForm.test.tsx
@@ -93,6 +93,7 @@ describe('Contact form', () => {
         color="#FF0000"
         recipientAddress=""
         isFavorite={false}
+        isNew
         onClickCancel={handleClick1}
         onClickDelete={handleClick2}
         onClickSaved={handleClick3}
@@ -158,6 +159,7 @@ describe('Contact form', () => {
         assignedAddress=""
         color=""
         isFavorite={false}
+        isNew
         onClickCancel={handleClick1}
         onClickDelete={handleClick2}
         onClickSaved={handleClick3}

--- a/app/pages/Contacts/ContactForm.view/ContactForm.view.tsx
+++ b/app/pages/Contacts/ContactForm.view/ContactForm.view.tsx
@@ -93,6 +93,7 @@ const ContactForm: FC<ContactFormProps> = ({
   color,
   isFavorite,
   recipientAddress,
+  isNew,
   onClickCancel,
   onClickDelete,
   onClickSaved,
@@ -103,7 +104,6 @@ const ContactForm: FC<ContactFormProps> = ({
   const [showPicker, setShowPicker] = useState(false);
 
   const { t } = useTranslation('ContactForm');
-  const isNew = !assignedAddress;
 
   return (
     <Container className={classes.cardContainer} maxWidth="sm">

--- a/app/pages/Contacts/ContactsPage.presenter/ContactsPage.presenter.tsx
+++ b/app/pages/Contacts/ContactsPage.presenter/ContactsPage.presenter.tsx
@@ -49,7 +49,7 @@ export const ContactsPage: FC = (): JSX.Element => {
     let assignedAddress;
     // fog accounts can not use assigned subaddresses for contacts
     // TODO change this to fog account, not just hardware wallet
-    if (!selectedAccount.account.managedByHardwareWallet) {
+    if (!selectedAccount.account.managedByHardwareWallet && !selectedAccount.account.fogEnabled) {
       const result = await assignAddressForAccount(
         selectedAccount.account.accountId || String(Math.random())
       );
@@ -120,7 +120,11 @@ export const ContactsPage: FC = (): JSX.Element => {
 
     case PAGE.ADD:
       return (
-        <ContactForm onClickCancel={() => setStatus(PAGE.LIST)} onClickSaved={addNewContact} />
+        <ContactForm
+          isNew
+          onClickCancel={() => setStatus(PAGE.LIST)}
+          onClickSaved={addNewContact}
+        />
       );
 
     case PAGE.EDIT:

--- a/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
+++ b/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
@@ -215,7 +215,7 @@ export const SendReceivePage: FC = (): JSX.Element => {
           throw new Error(t('sendBuildError'));
         }
 
-        if (formIsChecked) {
+        if (isChecked) {
           saveToContacts();
         }
 

--- a/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
+++ b/app/pages/SendReceive/SendReceivePage.presenter/SendReceivePage.presenter.tsx
@@ -108,12 +108,18 @@ export const SendReceivePage: FC = (): JSX.Element => {
       return RANDOM_COLORS[Math.floor(RANDOM_COLORS.length * Math.random())];
     };
 
-    const result = await assignAddressForAccount(selectedAccount.account.accountId as StringHex);
+    let assignedAddress: string | undefined;
+
+    if (!selectedAccount.account.managedByHardwareWallet && !selectedAccount.account.fogEnabled) {
+      assignedAddress = (
+        await assignAddressForAccount(selectedAccount.account.accountId as StringHex)
+      ).address.publicAddressB58;
+    }
 
     contacts.push({
       abbreviation: formAlias[0].toUpperCase(),
       alias: formAlias,
-      assignedAddress: result.address.publicAddressB58,
+      assignedAddress,
       color: randomColor(),
       id: uuidv4(),
       isFavorite: false,
@@ -207,6 +213,10 @@ export const SendReceivePage: FC = (): JSX.Element => {
         dispatch(setLoadingAction(false));
         if (result === null || result === undefined) {
           throw new Error(t('sendBuildError'));
+        }
+
+        if (formIsChecked) {
+          saveToContacts();
         }
 
         enqueueSnackbar(t('sendSuccess'), {


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Fog-based accounts and hardware wallet-based accounts don't support assigned subaddresses, which was causing saving contacts not to work when such an account was selected.

### In this PR

This PR:

- adds logic to skip assigning a subaddress when a fog based, or hardware wallet based account is selected.
- changes add vs. update contact logic to not use whether or not a subaddress is assigned as an indicator of whether or not a contact is new.
- adds the call to create a contact when a hardware wallet account is sending a transaction and the user has asked to save the destination address as a contact.

### Future Work

- noticed that sending a transaction from a hardware wallet does not clear the send form after a successful send. Fixing this is out-of-scope for this PR, but should be addressed or else if one misses the success snackbar, they may not realize that the transaction was sent.  Non-hardware wallet transactions clear the input form upon success.