### PR TITLE
add tgz, rpm, deb packages to linux CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,18 @@ jobs:
             runner: ubuntu-latest
             os: linux
             arch: x64
-            ext: AppImage
             network: mainnet
 
           - target: x86_64-apple-darwin
             runner: [self-hosted, macOS, X64]
             os: mac
             arch: x64
-            ext: dmg
             network: mainnet
 
           - target: aarch64-apple-darwin
             runner: [self-hosted, macOS, ARM64]
             os: mac
             arch: arm64
-            ext: dmg
             network: mainnet
 
     steps:
@@ -98,7 +95,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: mobilecoin-desktop-${{ matrix.target }}-${{ matrix.network }}
-        path: release/*.${{ matrix.ext }}
+        path: |
+          release/MobileCoin Wallet*
+          release/mobilecoin-wallet-*
 
     - name: Create prerelease for tagged versions
       if: startsWith(github.ref, 'refs/tags/v')
@@ -107,4 +106,6 @@ jobs:
         draft: true
         prerelease: true
         files: |
-          release/*.${{ matrix.ext }}
+          release/MobileCoin Wallet*
+          release/mobilecoin-wallet-*
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         name: mobilecoin-desktop-${{ matrix.target }}-${{ matrix.network }}
         path: |
           release/MobileCoin Wallet*
-          release/mobilecoin-wallet-*
+          release/mobilecoin-wallet*
 
     - name: Create prerelease for tagged versions
       if: startsWith(github.ref, 'refs/tags/v')
@@ -107,5 +107,5 @@ jobs:
         prerelease: true
         files: |
           release/MobileCoin Wallet*
-          release/mobilecoin-wallet-*
+          release/mobilecoin-wallet*
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,10 @@
     },
     "linux": {
       "target": [
-        "AppImage"
+	"tar.gz",
+        "AppImage",
+	"deb",
+	"rpm"
       ],
       "category": "Development"
     },

--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
     },
     "linux": {
       "target": [
-	"tar.gz",
+	      "tar.gz",
         "AppImage",
-	"deb",
-	"rpm"
+	      "deb",
+	      "rpm"
       ],
       "category": "Development"
     },


### PR DESCRIPTION
this pushes CI run time up to ~20 minutes (mostly spent compressing things), but it doesn't seem worth digging into the performance without first updating the node and electron versions etc., so, it is what it is for now.