### PR TITLE
Add testnet builds to github CI matrix, additional linux packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
         path: |
           release/MobileCoin Wallet*
           release/mobilecoin-wallet*
+          release/latest-*.yml
 
     - name: Create prerelease for tagged versions
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,14 @@ jobs:
         cp -r ./full-service-bin/${{ matrix.network }}/* ./full-service-bin/
         ls ./full-service-bin/
 
-    - name: Patch testnet build names
+    - name: Patch testnet build names and disable autoupdate
       if: ${{ matrix.network == 'testnet' }}
       run: |
         sed -i.bkp -e's/MobileCoin Wallet/MobileCoin Wallet TestNet/g' package.json
         sed -i.bkp -e's/mobilecoin-wallet/mobilecoin-wallet-testnet/g' package.json
         sed -i.bkp -e's/MobileCoin Wallet/MobileCoin Wallet TestNet/g' app/package.json
         sed -i.bkp -e's/mobilecoin-wallet/mobilecoin-wallet-testnet/g' app/package.json
+        sed -i.bkp -e's/new AppUpdater();//g' app/main.dev.ts
         yarn postinstall
 
     - name: Build and package app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,26 +23,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+          - runner: ubuntu-latest
             os: linux
             arch: x64
-            ext: AppImage
             network: mainnet
 
-          - target: x86_64-apple-darwin
-            runner: [self-hosted, macOS, X64]
+          - runner: [self-hosted, macOS, X64]
             os: mac
             arch: x64
-            ext: dmg
             network: mainnet
 
-          - target: aarch64-apple-darwin
-            runner: [self-hosted, macOS, ARM64]
+          - runner: [self-hosted, macOS, ARM64]
             os: mac
             arch: arm64
-            ext: dmg
             network: mainnet
+
+          - runner: ubuntu-latest
+            os: linux
+            arch: x64
+            network: testnet
+
+          - runner: [self-hosted, macOS, X64]
+            os: mac
+            arch: x64
+            network: testnet
+
+          - runner: [self-hosted, macOS, ARM64]
+            os: mac
+            arch: arm64
+            network: testnet
 
     steps:
     - uses: actions/checkout@v2
@@ -75,6 +84,7 @@ jobs:
       with:
         key: desktop-wallet-${{ matrix.os }}-${{ github.run_id }}
         restore-keys: desktop-wallet-${{ matrix.os }}
+        lookup-only: ${{ matrix.network == 'testnet' }}
         path: |
           ./node_modules
 
@@ -89,6 +99,15 @@ jobs:
         cp -r ./full-service-bin/${{ matrix.network }}/* ./full-service-bin/
         ls ./full-service-bin/
 
+    - name: Patch testnet build names
+      if: ${{ matrix.network == 'testnet' }}
+      run: |
+        sed -i.bkp -e's/MobileCoin Wallet/MobileCoin Wallet TestNet/g' package.json
+        sed -i.bkp -e's/mobilecoin-wallet/mobilecoin-wallet-testnet/g' package.json
+        sed -i.bkp -e's/MobileCoin Wallet/MobileCoin Wallet TestNet/g' app/package.json
+        sed -i.bkp -e's/mobilecoin-wallet/mobilecoin-wallet-testnet/g' app/package.json
+        yarn postinstall
+
     - name: Build and package app
       uses: borales/actions-yarn@v4
       with:
@@ -97,8 +116,10 @@ jobs:
     - name: Upload package artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: mobilecoin-desktop-${{ matrix.target }}-${{ matrix.network }}
-        path: release/*.${{ matrix.ext }}
+        name: mobilecoin-desktop-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.network }}
+        path: |
+          release/MobileCoin Wallet*
+          release/mobilecoin-wallet*
 
     - name: Create prerelease for tagged versions
       if: startsWith(github.ref, 'refs/tags/v')
@@ -107,4 +128,6 @@ jobs:
         draft: true
         prerelease: true
         files: |
-          release/*.${{ matrix.ext }}
+          release/MobileCoin Wallet*
+          release/mobilecoin-wallet*
+

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "package": "yarn build && electron-builder build --publish never",
     "package-all": "yarn build && electron-builder build -mwl",
     "package-ci": "yarn postinstall && yarn build && electron-builder --publish always",
-    "package-mac": "yarn build && electron-builder build --mac --publish never",
-    "package-linux": "yarn build && electron-builder build --linux --publish never",
+    "package-mac": "yarn build && electron-builder build --publish never --mac",
+    "package-linux": "yarn build && electron-builder build --publish never --linux",
     "package-linux-for-updater": "yarn build && electron-builder build --linux AppImage --publish never",
     "package-win": "yarn build && electron-builder build --win --x64 --publish never",
     "postinstall": "node -r @babel/register internals/scripts/CheckNativeDep.js && electron-builder install-app-deps && yarn build-dll && opencollective-postinstall",
@@ -106,7 +106,10 @@
     },
     "linux": {
       "target": [
-        "AppImage"
+        "tar.gz",
+        "AppImage",
+        "deb",
+        "rpm"
       ],
       "category": "Development"
     },


### PR DESCRIPTION
- builds both testnet and mainnet
- builds linux `deb`, `rpm`, `tar.gz` packages

fingers crossed this also triggers signing for macos builds once merged / now this is configured as one would expect, but, we'll have to see.

cc. @holtzman @briancorbin 