### PR TITLE
prepare for v1.9.0 release with updated full-serivce

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     env:
       # Pin full service binary version
-      FULL_SERVICE_VERSION: 'v2.8.0'
+      FULL_SERVICE_VERSION: 'v2.10.1'
       # Apple codesigning certs
       CSC_LINK: ${{ secrets.CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobilecoin-wallet",
   "productName": "MobileCoin Wallet",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Desktop hot wallet for your MobileCoin needs.",
   "main": "./main.prod.js",
   "author": {

--- a/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
+++ b/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
@@ -78,6 +78,7 @@ const untilFullServiceRuns = async (enqueueSnackbar, closeSnackbar) => {
       // full-service to be ready for normal operation.
       if (estr.includes('Resync in progress')) {
         i = 0;
+        // rightmost 14 characters of response from full-service is (%xx complete)
         const msg = `Wallet DB being upgraded, please standby ${estr.slice(-14)}`;
         const key = enqueueSnackbar(msg, { persist: true, variant: 'warning' });
         await new Promise((resolve) => setTimeout(resolve, 30000));

--- a/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
+++ b/app/pages/Auth/AuthPage.presenter/AuthPage.presenter.tsx
@@ -65,13 +65,26 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 /* eslint-disable no-await-in-loop */
-const untilFullServiceRuns = async () => {
+const untilFullServiceRuns = async (enqueueSnackbar, closeSnackbar) => {
   for (let i = 0; i < 25; i++) {
     try {
       await getAllAccounts();
       return true;
     } catch (e) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const estr = errorToString(e);
+      // On certain upgrades, full-service has started, but won't respond to requests while it
+      // resyncs the wallet db from the ledger.
+      // keep the user informed of the progress, while waiting for
+      // full-service to be ready for normal operation.
+      if (estr.includes('Resync in progress')) {
+        i = 0;
+        const msg = `Wallet DB being upgraded, please standby ${estr.slice(-14)}`;
+        const key = enqueueSnackbar(msg, { persist: true, variant: 'warning' });
+        await new Promise((resolve) => setTimeout(resolve, 30000));
+        closeSnackbar(key);
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
     }
   }
 
@@ -89,7 +102,7 @@ export const AuthPage: FC = (): JSX.Element => {
   const [fullServiceIsRunning, setFullServiceIsRunning] = useState(false);
   const [loading, setLoading] = useState(true);
   const [accountIds, setAccountIds] = useState<string[]>([]);
-  const { enqueueSnackbar } = useSnackbar();
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
   const offlineStart = localStore.getOfflineStart();
   useEffect(() => {
@@ -139,7 +152,7 @@ export const AuthPage: FC = (): JSX.Element => {
         try {
           await validatePassphrase(password, encryptedPassword);
           await ipcRenderer.invoke('start-full-service', password, null, startInOfflineMode);
-          await untilFullServiceRuns();
+          await untilFullServiceRuns(enqueueSnackbar, closeSnackbar);
           const accounts = await getAllAccounts();
           setAccountIds(accounts.accountIds);
           await unlockWallet(password, startInOfflineMode);

--- a/full-service-bin/mainnet/start-full-service.sh
+++ b/full-service-bin/mainnet/start-full-service.sh
@@ -22,7 +22,7 @@ mkdir -p "${WALLET_DB_DIR}"
 
 echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}"
 
-RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
+RUST_LOG=info,mc_connection=error,mc_ledger_sync=info ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \
         --wallet-db "${WALLET_DB_FILE}" \
         --chain-id "main" \

--- a/full-service-bin/testnet/start-full-service.sh
+++ b/full-service-bin/testnet/start-full-service.sh
@@ -22,7 +22,7 @@ mkdir -p "${WALLET_DB_DIR}"
 
 echo "Starting full-service with ${LEDGER_DB_DIR} and ${WALLET_DB_DIR} and ${WALLET_DB_FILE}"
 
-RUST_LOG=debug,mc_connection=error,mc_ledger_sync=error ./full-service \
+RUST_LOG=info,mc_connection=error,mc_ledger_sync=info ./full-service \
         --ledger-db "${LEDGER_DB_DIR}" \
         --wallet-db "${WALLET_DB_FILE}" \
         --chain-id "test" \

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobilecoin-wallet",
   "productName": "MobileCoin Wallet",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Desktop hot wallet for your MobileCoin needs.",
   "scripts": {
     "build": "concurrently \"yarn build-main\" \"yarn build-renderer\"",


### PR DESCRIPTION
### Motivation

In preparing for the MobileCoin blockchain to update to v6.0.0 of Consensus and Fog, Desktop Wallet needs to be re-released with an updated embedded full-service that can attest to the v6.0.0 blockchain.

Since the last Desktop Wallet release, full-service has also included wallet-db changes that will cause any pre-existing wallets to undergo a forced rsync of the wallet-db with the ledger-db.  This is a lengthly process that would time out desktop wallets initial connection with full-service

### In this PR

This PR
* updates the embedded full-service to v2.10.1 which is compatible both with MobileCoin core v5.0.0 and Mobile core v6.0.0.
* updates the Desktop Wallet version string to v1.9.0
* updates Desktop Wallet to wait for for full-service to resync the wallet-db, if it is doing so on launch.
* provides notice to the user that the wallet-db is being upgraded, along with progress indication.