### PR TITLE
notarize mac builds using notarytool

### DIFF
--- a/afterSignHook.js
+++ b/afterSignHook.js
@@ -20,11 +20,11 @@ module.exports = async function (params) {
 
   try {
     await electron_notarize.notarize({
-      appBundleId: appId,
+      tool: 'notarytool',
       appPath,
       appleId: process.env.APPLE_ID,
       appleIdPassword: process.env.APPLE_ID_PASSWORD,
-      ascProvider: process.env.APPLE_TEAM_ID,
+      teamId: process.env.APPLE_TEAM_ID,
     });
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
### Motivation

Apple's legacy altool may no longer be used to notarize apps for MacOS use.  We want Desktop Wallet to be notarized so that users know the app is genuinely from us, and also so that they do not have to override security settings to use the app.

### In this PR

* tell electron-notarize to use the newer notarytool instead of the legacy altool (default)
* update the notarization params for notarytool