### PR TITLE
lift up history list state to history page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
             arch: x64
             network: mainnet
 
-          - runner: [self-hosted, macOS, X64]
-            os: mac
-            arch: x64
-            network: mainnet
+          # - runner: [self-hosted, macOS, X64]
+          #   os: mac
+          #   arch: x64
+          #   network: mainnet
 
-          - runner: [self-hosted, macOS, ARM64]
+          - runner: macos-latest
             os: mac
             arch: arm64
             network: mainnet
@@ -50,12 +50,12 @@ jobs:
             arch: x64
             network: testnet
 
-          - runner: [self-hosted, macOS, X64]
-            os: mac
-            arch: x64
-            network: testnet
+          # - runner: [self-hosted, macOS, X64]
+          #   os: mac
+          #   arch: x64
+          #   network: testnet
 
-          - runner: [self-hosted, macOS, ARM64]
+          - runner: macos-latest
             os: mac
             arch: arm64
             network: testnet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
             arch: x64
             network: mainnet
 
-          # - runner: [self-hosted, macOS, X64]
-          #   os: mac
-          #   arch: x64
-          #   network: mainnet
+          - runner: [self-hosted, macOS, X64]
+            os: mac
+            arch: x64
+            network: mainnet
 
-          - runner: macos-latest
+          - runner: [self-hosted, macOS, ARM64]
             os: mac
             arch: arm64
             network: mainnet
@@ -50,12 +50,12 @@ jobs:
             arch: x64
             network: testnet
 
-          # - runner: [self-hosted, macOS, X64]
-          #   os: mac
-          #   arch: x64
-          #   network: testnet
+          - runner: [self-hosted, macOS, X64]
+            os: mac
+            arch: x64
+            network: testnet
 
-          - runner: macos-latest
+          - runner: [self-hosted, macOS, ARM64]
             os: mac
             arch: arm64
             network: testnet

--- a/app/pages/History/HistoryList.view/HistoryList.d.ts
+++ b/app/pages/History/HistoryList.view/HistoryList.d.ts
@@ -3,4 +3,8 @@ import type { TransactionLog } from '../../../types/TransactionLog.d';
 export interface HistoryListProps {
   onTransactionClick: (transactionLog: TransactionLog) => void;
   transactionLogsList: TransactionLog[];
+  firstToShow: number;
+  setFirstToShow: (value: number) => void;
+  selectedTabIndex: number;
+  setSelectedTabIndex: (value: number) => void;
 }

--- a/app/pages/History/HistoryList.view/HistoryList.test.tsx
+++ b/app/pages/History/HistoryList.view/HistoryList.test.tsx
@@ -11,35 +11,98 @@ import '../../../testUtils/i18nForTests';
 import { HistoryList } from './HistoryList.view';
 
 describe('History list', () => {
-  test('displays TXOs according to selection', () => {
+  const testTransactionLogs = [
+    {
+      assignedAddressId: 'XYZABC123456',
+      contact: undefined,
+      direction: 'tx_direction_sent',
+      finalizedBlockIndex: '123456',
+      recipientAddressId: null,
+      tokenId: 0,
+      transactionLogId: '123456',
+      value: '220960000000',
+    } as TransactionLog,
+    {
+      assignedAddressId: 'LMNTARYWATSON',
+      contact: undefined,
+      direction: 'tx_direction_received',
+      finalizedBlockIndex: '345678',
+      recipientAddressId: '101010101010101',
+      tokenId: 0,
+      transactionLogId: '789012',
+      value: '31415926',
+    } as TransactionLog,
+  ];
+
+  test('displays TXOs according to selection = ALL', () => {
     const handleClick = jest.fn();
 
     const { container } = render(
       <Provider store={store}>
         <HistoryList
-          transactionLogsList={[
-            {
-              assignedAddressId: 'XYZABC123456',
-              contact: undefined,
-              direction: 'tx_direction_sent',
-              finalizedBlockIndex: '123456',
-              recipientAddressId: null,
-              tokenId: 0,
-              transactionLogId: '123456',
-              value: '220960000000',
-            } as TransactionLog,
-            {
-              assignedAddressId: 'LMNTARYWATSON',
-              contact: undefined,
-              direction: 'tx_direction_received',
-              finalizedBlockIndex: '345678',
-              recipientAddressId: '101010101010101',
-              tokenId: 0,
-              transactionLogId: '789012',
-              value: '31415926',
-            } as TransactionLog,
-          ]}
+          transactionLogsList={testTransactionLogs}
+          firstToShow={0}
+          setFirstToShow={jest.fn()}
+          selectedTabIndex={0}
+          setSelectedTabIndex={jest.fn()}
           onTransactionClick={handleClick}
+        />
+      </Provider>
+    );
+    expect(container.innerHTML.includes('-0.220960000000')).toBeTruthy();
+    expect(container.innerHTML.includes('+0.000031415926')).toBeTruthy();
+  });
+
+  test('displays TXOs according to selection = Sent', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <HistoryList
+          transactionLogsList={testTransactionLogs}
+          firstToShow={0}
+          setFirstToShow={jest.fn()}
+          selectedTabIndex={1}
+          setSelectedTabIndex={jest.fn()}
+          onTransactionClick={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(container.innerHTML.includes('-0.220960000000')).toBeTruthy();
+    expect(container.innerHTML.includes('+0.000031415926')).toBeFalsy();
+  });
+
+  test('displays TXOs according to selection = Received', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <HistoryList
+          transactionLogsList={testTransactionLogs}
+          firstToShow={0}
+          setFirstToShow={jest.fn()}
+          selectedTabIndex={2}
+          setSelectedTabIndex={jest.fn()}
+          onTransactionClick={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(container.innerHTML.includes('-0.220960000000')).toBeFalsy();
+    expect(container.innerHTML.includes('+0.000031415926')).toBeTruthy();
+  });
+
+  test('tab selection changes as it should', () => {
+    let tabIndex = 0;
+
+    const setSelectedTabIndex = (value: number) => {
+      tabIndex = value;
+    };
+
+    const { container } = render(
+      <Provider store={store}>
+        <HistoryList
+          transactionLogsList={testTransactionLogs}
+          firstToShow={0}
+          setFirstToShow={jest.fn()}
+          selectedTabIndex={tabIndex}
+          setSelectedTabIndex={setSelectedTabIndex}
+          onTransactionClick={jest.fn()}
         />
       </Provider>
     );
@@ -48,19 +111,13 @@ describe('History list', () => {
     const showSent = container.querySelector('[id="show-sent"]') as HTMLInputElement;
     const showReceived = container.querySelector('[id="show-received"]') as HTMLInputElement;
 
-    expect(container.innerHTML.includes('-0.220960000000')).toBeTruthy();
-    expect(container.innerHTML.includes('+0.000031415926')).toBeTruthy();
-
     userEvent.click(showSent);
-    expect(container.innerHTML.includes('-0.220960000000')).toBeTruthy();
-    expect(container.innerHTML.includes('+0.000031415926')).toBeFalsy();
+    expect(tabIndex).toBe(1);
 
     userEvent.click(showReceived);
-    expect(container.innerHTML.includes('-0.220960000000')).toBeFalsy();
-    expect(container.innerHTML.includes('+0.000031415926')).toBeTruthy();
+    expect(tabIndex).toBe(2);
 
     userEvent.click(showAll);
-    expect(container.innerHTML.includes('-0.220960000000')).toBeTruthy();
-    expect(container.innerHTML.includes('+0.000031415926')).toBeTruthy();
+    expect(tabIndex).toBe(0);
   });
 });

--- a/app/pages/History/HistoryList.view/HistoryList.view.tsx
+++ b/app/pages/History/HistoryList.view/HistoryList.view.tsx
@@ -19,12 +19,14 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const HistoryList: FC<HistoryListProps> = ({
   transactionLogsList,
+  firstToShow,
+  setFirstToShow,
+  selectedTabIndex,
+  setSelectedTabIndex,
   onTransactionClick,
 }: HistoryListProps) => {
   const classes = useStyles();
-  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [dataToShow, setDataToShow] = useState(transactionLogsList);
-  const [firstToShow, setFirstToShow] = useState(0);
 
   const pageBack = () => setFirstToShow(firstToShow - HISTORY_PAGE_SIZE);
   const pageForward = () => setFirstToShow(firstToShow + HISTORY_PAGE_SIZE);

--- a/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
+++ b/app/pages/History/HistoryPage.presenter/HistoryPage.presenter.tsx
@@ -26,6 +26,8 @@ export const HistoryPage: FC = (): JSX.Element => {
   const [currentTransactionLog, setCurrentTransaction] = useState({} as TransactionLog);
   const [txoValidations, setTxoValidations] = useState({});
   const [showing, setShowing] = useState(HISTORY);
+  const [firstToShow, setFirstToShow] = useState(0);
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const { t } = useTranslation('HistoryView');
   const { enqueueSnackbar } = useSnackbar();
   const logs = useTransactionLogs();
@@ -98,6 +100,10 @@ export const HistoryPage: FC = (): JSX.Element => {
       return (
         <HistoryList
           transactionLogsList={logs}
+          firstToShow={firstToShow}
+          setFirstToShow={setFirstToShow}
+          selectedTabIndex={selectedTabIndex}
+          setSelectedTabIndex={setSelectedTabIndex}
           onTransactionClick={(transactionLog) => {
             setCurrentTransaction(transactionLog);
             setShowing(DETAILS);

--- a/app/pages/Settings/ConfigureFullService.view/__snapshots__/ConfigureFullService.test.tsx.snap
+++ b/app/pages/Settings/ConfigureFullService.view/__snapshots__/ConfigureFullService.test.tsx.snap
@@ -416,6 +416,23 @@ exports[`ConfigureFullServiceView component render ConfigureFullServiceView rend
             undefined
           </p>
         </div>
+        <div
+          class="MuiBox-root MuiBox-root-30"
+        />
+        <p
+          class="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextPrimary"
+        >
+          Full-Serice Logs Path
+        </p>
+        <div
+          style="cursor: pointer;"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextSecondary"
+          >
+            /tmp
+          </p>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation

When viewing an account history, if one navigates to an entry's details and then hits the "go back" button, it should take you back to where you were in the paginated history list.

### In this PR

- lift-up the state tracking of both pagination (`firstToShow`) and filtering (`selectedTabIndex`) from the `HistoryList` component to the `HistoryPage` component so that this state is not lost due to `HistoryPage` rendering the `TransactionDetails` component instead of the `HistoryList` component when the user clicks on a list entry, and next clicks the `Go Back` button.

### Caveats

This PR just passes the setters for `firstToShow` and `selectedTabIndex` into `HistoryList`, having lifted the state tracking up to `HistoryPage`.  While the practice of directly sharing state setters into sub-components is generally frowned upon, that is for the use case of sharing state between sub-components and to make the code more debuggable when unexpected state changes happen.

We think in this case, it is acceptable because all of the setting is being done in `HistoryList`.  We just need to lift these pieces of state up to the enclosing component as it removes `HistoryList` from the tree and then returns it later and we want this bit of state to survive that toggling of what is displayed.
